### PR TITLE
add omit

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
       "types": "./dist/set-has.d.ts",
       "default": "./dist/set-has.js"
     },
+    "./omit": {
+      "import": "./dist/omit.mjs",
+      "types": "./dist/omit.d.ts",
+      "default": "./dist/omit.js"
+    },
     "./utils": {
       "import": "./dist/utils.mjs",
       "types": "./dist/utils.d.ts",

--- a/readme.md
+++ b/readme.md
@@ -256,6 +256,34 @@ const validate = (input: unknown) => {
 };
 ```
 
+### Improve `Omit` util 
+
+```ts
+import "@total-typescript/ts-reset/omit";
+```
+
+When you're using Omit type there's a chance to make a typo in the key name
+
+```ts
+// BEFORE
+interface Obj {
+  key: string;
+}
+
+type R1 = Omit<Obj, 'key2'>; // OK
+```
+
+```ts
+// After
+import "@total-typescript/ts-reset/omit";
+
+interface Obj {
+  key: string;
+}
+
+type R1 = Omit<Obj, 'key2'>; // Type '"key2"' does not satisfy the constraint '"key"'.
+```
+
 ## Rules we won't add
 
 ### `Object.keys`/`Object.entries`

--- a/src/entrypoints/omit.d.ts
+++ b/src/entrypoints/omit.d.ts
@@ -1,0 +1,3 @@
+export type Omit<T, K extends keyof T> = {
+    [P in Exclude<keyof T, K>]: T[P];
+  };

--- a/src/entrypoints/recommended.d.ts
+++ b/src/entrypoints/recommended.d.ts
@@ -4,3 +4,4 @@
 /// <reference path="json-parse.d.ts" />
 /// <reference path="array-includes.d.ts" />
 /// <reference path="set-has.d.ts" />
+/// <reference path="omit.d.ts" />

--- a/src/tests/omit.ts
+++ b/src/tests/omit.ts
@@ -1,0 +1,9 @@
+import { doNotExecute } from "./utils";
+
+doNotExecute(() => {
+    interface Obj {
+        key: string;
+    }
+
+    type R1 = Omit<Obj, 'key2'>
+});


### PR DESCRIPTION
I noticed that the built-in Omit util doesn't throw an error when you're omitting not existing key. I think it can be easily improved.

[playground](https://www.typescriptlang.org/play?#code/KYDwDg9gTgLgBDAnmYcDyBbAljATAHgBUAaOAaTlBmADsATAZzgGthEIAzOQgPjgF44AbwBQcOAG0ACnCw04AURABjADYBXOsHyt2XEuR4BdAFzdpRgNwiAvtZFzqUDgENlqNACMAVsLHiWNjMGGCg5AHNrGxERJBQ4ACUARgF0bBh8L29SAHJdXByeWORUBNxUzBwCLNz8wqA)

```ts
export type Omit2<T, K extends keyof T> = {
  [P in Exclude<keyof T, K>]: T[P];
};

interface Obj {
    key: string;
}

type R1 = Omit<Obj, 'key2'> // OK
type R2 = Omit2<Obj, 'key2'> // Type '"key2"' does not satisfy the constraint '"key"'.(2344)
```

P.S. I'm not sure about test file. I'm open for suggestion