### PR TITLE
Smarter types for Object.keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
       "import": "./dist/array-includes.mjs",
       "default": "./dist/array-includes.js"
     },
+    "./object-keys": {
+      "types": "./dist/object-keys.d.ts",
+      "import": "./dist/object-keys.mjs",
+      "default": "./dist/object-keys.js"
+    },
     "./set-has": {
       "types": "./dist/set-has.d.ts",
       "import": "./dist/set-has.mjs",

--- a/src/entrypoints/object-keys.d.ts
+++ b/src/entrypoints/object-keys.d.ts
@@ -1,0 +1,15 @@
+interface ObjectConstructor {
+  /**
+   * Returns the names of the enumerable string properties and methods of an object.
+   * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+   */
+  keys<T extends {}>(
+    o: T
+  ): T extends any[]
+    ? string[]
+    : T extends Record<any, any>
+    ? object extends T
+      ? string[]
+      : (keyof T & string)[]
+    : string[];
+}

--- a/src/tests/object-keys.ts
+++ b/src/tests/object-keys.ts
@@ -1,0 +1,57 @@
+import { doNotExecute, Equal, Expect } from "./utils";
+
+doNotExecute(() => {
+  // @ts-expect-error - Value cannot be undefined
+  Object.keys(undefined);
+  // @ts-expect-error - Value cannot be null
+  Object.keys(null);
+});
+
+doNotExecute(() => {
+  // Calling Object.keys on a non-nullish primitive, should not try to do
+  // anything smart (in reality this will be an empty array)
+  const result = Object.keys(5);
+  type tests = [Expect<Equal<typeof result, string[]>>];
+});
+
+doNotExecute(() => {
+  // Calling Object.keys on a non-tuple array should result in string[]
+  const result = Object.keys([1, 2, 3]);
+  type tests = [Expect<Equal<typeof result, string[]>>];
+});
+
+doNotExecute(() => {
+  const tuple: [number, number] = [0, 0];
+  const result = Object.keys(tuple);
+  // We could probably try to infer that the result is `['1', '2']` but this
+  // implementation does't go that far down the rabbit hole.
+  type tests = [Expect<Equal<typeof result, string[]>>];
+});
+
+doNotExecute(() => {
+  const result = Object.keys({ a: 1, b: 2 });
+  type tests = [Expect<Equal<typeof result, ("a" | "b")[]>>];
+});
+
+doNotExecute(() => {
+  const obj: any = {};
+  const result = Object.keys(obj);
+  type tests = [Expect<Equal<typeof result, string[]>>];
+});
+
+doNotExecute(() => {
+  const obj: object = {};
+  const result = Object.keys(obj);
+  type tests = [Expect<Equal<typeof result, string[]>>];
+});
+
+doNotExecute(() => {
+  const obj: Record<string, any> = {};
+  const result = Object.keys(obj);
+  type tests = [Expect<Equal<typeof result, string[]>>];
+});
+
+doNotExecute(() => {
+  const result = Object.keys({});
+  type tests = [Expect<Equal<typeof result, string[]>>];
+});


### PR DESCRIPTION
This doesn't directly increase soundness, but it makes `Object.keys()` return smarter (more specific) types when we have a known set of keys. This leads to a significantly better developer experience and reduces the need for devs to use `as` and by extension increase type safety.

The canonical example is as follows ([playground](https://www.typescriptlang.org/play?noUncheckedIndexedAccess=true&alwaysStrict=false&target=99#code/MYewdgzgLgBCBGArGBeGBvGBDAXDAjADQzx4BMMAvgNwBQtAZiAE4wAUoksA1gKYCecBjADySXsCgA6PvwhsEiAJRKMtGDAD0mmABV+ABwCWwLABszgrDAAmvAG4wA7iACuZmzFcReMAAZYEH4wABa8zL5QIDAAtlh8MFAhRhAw4cwsMADm0VhOWPxS6jCcECBmvFJmIFkKSADasgC6SnSUtEA)):
```ts
const obj = { a: 1, b: 2 };

for (const key of Object.keys(obj)) {
  console.log(obj[key]); // <-- Error: No index signature with a parameter of type 'string' was found on type '{ a: number; b: number; }'
}
```

After this PR, using ts-reset makes this problem go away 🎉

Note: We can do something similar with `Object.entries()` but I didn't tackle that in this PR.
