### PR TITLE
Add string-case types

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
       "import": "./dist/set-has.mjs",
       "default": "./dist/set-has.js"
     },
+    "./string-case": {
+      "types": "./dist/string-case.d.ts",
+      "import": "./dist/string-case.mjs",
+      "default": "./dist/string-case.js"
+    },
     "./utils": {
       "types": "./dist/utils.d.ts",
       "import": "./dist/utils.mjs",

--- a/src/entrypoints/string-case.d.ts
+++ b/src/entrypoints/string-case.d.ts
@@ -1,4 +1,6 @@
 interface String {
   toLowerCase<T extends string>(this: T): Lowercase<T>;
+  toLocaleLowerCase<T extends string>(this: T): Lowercase<T>;
   toUpperCase<T extends string>(this: T): Uppercase<T>;
+  toLocaleUpperCase<T extends string>(this: T): Uppercase<T>;
 }

--- a/src/entrypoints/string-case.d.ts
+++ b/src/entrypoints/string-case.d.ts
@@ -1,0 +1,4 @@
+interface String {
+  toLowerCase<T extends string>(this: T): Lowercase<T>;
+  toUpperCase<T extends string>(this: T): Uppercase<T>;
+}

--- a/src/tests/string-case.ts
+++ b/src/tests/string-case.ts
@@ -19,6 +19,24 @@ doNotExecute(async () => {
 });
 
 doNotExecute(async () => {
+  const string: "A" | "B" = "A";
+
+  const lowerCaseString = string.toLocaleLowerCase();
+
+  type tests = [Expect<NotEqual<typeof string, typeof lowerCaseString>>];
+});
+
+doNotExecute(async () => {
+  const string: "A" | "B" = "A";
+
+  const lowerCaseString = string.toLocaleLowerCase();
+
+  type tests = [
+    Expect<Equal<Lowercase<typeof string>, typeof lowerCaseString>>
+  ];
+});
+
+doNotExecute(async () => {
   const string: "a" | "b" = "a";
 
   const upperCaseString = string.toUpperCase();
@@ -30,6 +48,24 @@ doNotExecute(async () => {
   const string: "a" | "b" = "a";
 
   const upperCaseString = string.toUpperCase();
+
+  type tests = [
+    Expect<Equal<Uppercase<typeof string>, typeof upperCaseString>>
+  ];
+});
+
+doNotExecute(async () => {
+  const string: "a" | "b" = "a";
+
+  const upperCaseString = string.toLocaleUpperCase();
+
+  type tests = [Expect<NotEqual<typeof string, typeof upperCaseString>>];
+});
+
+doNotExecute(async () => {
+  const string: "a" | "b" = "a";
+
+  const upperCaseString = string.toLocaleUpperCase();
 
   type tests = [
     Expect<Equal<Uppercase<typeof string>, typeof upperCaseString>>

--- a/src/tests/string-case.ts
+++ b/src/tests/string-case.ts
@@ -1,0 +1,37 @@
+import { doNotExecute, Expect, NotEqual, Equal } from "./utils";
+
+doNotExecute(async () => {
+  const string: "A" | "B" = "A";
+
+  const lowerCaseString = string.toLowerCase();
+
+  type tests = [Expect<NotEqual<typeof string, typeof lowerCaseString>>];
+});
+
+doNotExecute(async () => {
+  const string: "A" | "B" = "A";
+
+  const lowerCaseString = string.toLowerCase();
+
+  type tests = [
+    Expect<Equal<Lowercase<typeof string>, typeof lowerCaseString>>
+  ];
+});
+
+doNotExecute(async () => {
+  const string: "a" | "b" = "a";
+
+  const upperCaseString = string.toUpperCase();
+
+  type tests = [Expect<NotEqual<typeof string, typeof upperCaseString>>];
+});
+
+doNotExecute(async () => {
+  const string: "a" | "b" = "a";
+
+  const upperCaseString = string.toUpperCase();
+
+  type tests = [
+    Expect<Equal<Uppercase<typeof string>, typeof upperCaseString>>
+  ];
+});

--- a/src/tests/string-case.ts
+++ b/src/tests/string-case.ts
@@ -9,12 +9,12 @@ doNotExecute(async () => {
 });
 
 doNotExecute(async () => {
-  const string: "A" | "B" = "A";
+  const string = "A" as "A" | "B";
 
   const lowerCaseString = string.toLowerCase();
 
   type tests = [
-    Expect<Equal<Lowercase<typeof string>, typeof lowerCaseString>>
+    Expect<Equal<typeof lowerCaseString, "a" | "b">>
   ];
 });
 


### PR DESCRIPTION
This solves #16 

```typescript
type Union = "a" | "b" | "c";

const foo: Union = "a";

const fooUpperCased: Uppercase<Union> = foo.toUpperCase(); // should be 'A' | 'B' | 'C'
```