### PR TITLE
Fix readme with correct types of fetch and JSON.parse

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Whenever you add TypeScript to a project, you're opting into **tens of thousands
 
 These typings are not perfect.
 
-- `.json` (in `fetch`) and `JSON.parse` both return `any`
+- `.json` (in `fetch`) and `JSON.parse` both return `unknown`
 - `.filter(Boolean)` doesn't behave how you expect
 - `array.includes` often breaks on readonly arrays
 


### PR DESCRIPTION
Looking at the code:

- https://github.com/total-typescript/ts-reset/blob/2ed98679/src/entrypoints/fetch.d.ts#L2
- https://github.com/total-typescript/ts-reset/blob/2ed98679/src/entrypoints/json-parse.d.ts#L11

and the rest of the readme:

- https://github.com/total-typescript/ts-reset/blob/2ed98679/readme.md?plain=1#L71
- https://github.com/total-typescript/ts-reset/blob/2ed98679/readme.md?plain=1#L93

it seems that both `.json()` from `fetch` and `JSON.parse()` already return `unknown` instead of `any` (and rightly so, I might add!)

(Sidenote: reading that they return `any` was a reason I dismissed this lib as not safe yet in this regard and wanted to prepare a PR proposing of changing it to `unknown` but looking at the code it turned out to already be the case, so it would be good to fix the readme and not scare others. By the way, thanks for creating this project, very good idea!)

This PR just fixes the intro of the readme to make it consistent.