### PR TITLE
Make isNaN also take string as input for string use cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
       "import": "./dist/set-has.mjs",
       "default": "./dist/set-has.js"
     },
+    "./is-nan": {
+      "types": "./dist/is-nan.d.ts",
+      "import": "./dist/is-nan.mjs",
+      "default": "./dist/is-nan.js"
+    },
     "./utils": {
       "types": "./dist/utils.d.ts",
       "import": "./dist/utils.mjs",

--- a/src/entrypoints/is-nan.d.ts
+++ b/src/entrypoints/is-nan.d.ts
@@ -1,0 +1,1 @@
+declare function isNaN(num: number | string): boolean;

--- a/src/tests/is-nan.ts
+++ b/src/tests/is-nan.ts
@@ -1,0 +1,9 @@
+import { doNotExecute } from "./utils";
+
+doNotExecute(() => {
+    isNaN(12345);
+    isNaN("12345");
+    isNaN(NaN);
+    isNaN("string");
+    isNaN("1.1111");
+});


### PR DESCRIPTION
This allows isNaN to be used for checking if a string is a number.