### PR TITLE
Add boolean predicate

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
       "import": "./dist/set-has.mjs",
       "default": "./dist/set-has.js"
     },
+    "./boolean-predicate": {
+      "types": "./dist/boolean-predicate.d.ts",
+      "import": "./dist/boolean-predicate.mjs",
+      "default": "./dist/boolean-predicate.js"
+    },
     "./utils": {
       "types": "./dist/utils.d.ts",
       "import": "./dist/utils.mjs",

--- a/readme.md
+++ b/readme.md
@@ -260,6 +260,41 @@ const validate = (input: unknown) => {
 };
 ```
 
+### Boolean(val) is now also a predicate
+
+```ts
+import "@total-typescript/ts-reset/boolean-predicate";
+```
+
+When you're using `Boolean(val)`, Typescript doesn't understand it as a predicate on `val`.
+
+```ts
+// BEFORE
+
+const getUserName = (user?: User) => {
+  const isUser = Boolean(user);
+  if (isUser) {
+    console.log(user.name); // error: user is possibly undefined
+  }
+};
+```
+
+With this rule enabled, `Boolean(val)` is now also a type predicate. This means you can use it to narrow types:
+
+```ts
+// AFTER
+import "@total-typescript/ts-reset/is-array";
+
+const getUserName = (user?: User) => {
+  const isUser = Boolean(user);
+  if (isUser) {
+    console.log(user.name); // ✅
+  }
+};
+```
+
+> **Caveat:** Since the constructor typing is unchanged, this can only work for the cases where `Boolean(val)` is used explicitly, and not for `.filter(Boolean)`. For that, you'll need to use `filter-boolean`.
+
 ## Rules we won't add
 
 ### `Object.keys`/`Object.entries`

--- a/src/entrypoints/boolean-predicate.d.ts
+++ b/src/entrypoints/boolean-predicate.d.ts
@@ -1,0 +1,7 @@
+/// <reference path="utils.d.ts" />
+
+interface BooleanConstructor {
+  new (value?: any): Boolean;
+  <T>(value?: T): value is TSReset.NonFalsy<T>;
+  readonly prototype: Boolean;
+}

--- a/src/tests/boolean-predicate.ts
+++ b/src/tests/boolean-predicate.ts
@@ -1,0 +1,39 @@
+import { doNotExecute, Equal, Expect } from "./utils";
+
+doNotExecute(() => {
+  let obj: { foo: "bar" } | undefined;
+
+  if (Boolean(obj)) {
+    type test = Expect<Equal<typeof obj, { foo: "bar" }>>;
+  } else {
+    type test = Expect<Equal<typeof obj, undefined>>;
+  }
+});
+
+doNotExecute(() => {
+  let obj: "" | 0 | undefined;
+
+  if (Boolean(obj)) {
+    type test = Expect<Equal<typeof obj, never>>;
+  } else {
+    type test = Expect<Equal<typeof obj, "" | 0 | undefined>>;
+  }
+});
+
+doNotExecute(() => {
+  let obj: 1 | "" | 0 | undefined;
+
+  if (Boolean(obj)) {
+    type test = Expect<Equal<typeof obj, 1>>;
+  } else {
+    type test = Expect<Equal<typeof obj, "" | 0 | undefined>>;
+  }
+});
+
+doNotExecute(() => {
+  let obj: any;
+
+  const result = Boolean(obj);
+
+  type test = Expect<Equal<typeof result, boolean>>;
+});

--- a/src/tests/boolean-predicate.ts
+++ b/src/tests/boolean-predicate.ts
@@ -1,4 +1,4 @@
-import { doNotExecute, Equal, Expect } from "./utils";
+import { doNotExecute, Equal, NotEqual, Expect } from "./utils";
 
 doNotExecute(() => {
   let obj: { foo: "bar" } | undefined;
@@ -36,4 +36,28 @@ doNotExecute(() => {
   const result = Boolean(obj);
 
   type test = Expect<Equal<typeof result, boolean>>;
+});
+
+doNotExecute(() => {
+  let obj = {} as any[];
+
+  const result = Boolean(obj);
+
+  type tests = [
+    Expect<Equal<typeof result, boolean>>,
+    Expect<Equal<typeof obj, any[]>>,
+    Expect<NotEqual<typeof obj, unknown[]>>
+  ];
+});
+
+doNotExecute(() => {
+  let obj = {} as unknown[];
+
+  const result = Boolean(obj);
+
+  type tests = [
+    Expect<Equal<typeof result, boolean>>,
+    Expect<Equal<typeof obj, unknown[]>>,
+    Expect<NotEqual<typeof obj, any[]>>
+  ];
 });


### PR DESCRIPTION
Resolves #35

No breaking changes, just making the function typing of `Boolean` work as a predicate.