### PR TITLE
accept generic argument as json conversion in fetch body interface

### DIFF
--- a/src/entrypoints/fetch.d.ts
+++ b/src/entrypoints/fetch.d.ts
@@ -1,3 +1,3 @@
 interface Body {
-  json(): Promise<unknown>;
+  json<T>(): Promise<T>;
 }


### PR DESCRIPTION
Instead of returning unknown in JSON we can accept Generic type same as Axios so when JSON conversion is successful we do not have to explicitly type it