### PR TITLE
Make `Object.assign()` know that it's added values to the target

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -260,6 +260,30 @@ const validate = (input: unknown) => {
 };
 ```
 
+### Make `Object.assign()` know that it's added values to the target
+
+```ts
+import "@total-typescript/ts-reset/object-assign";
+```
+
+This rule improves on the `Object.assign` method, and asserts that the target is both the target and the source.
+
+```ts
+// BEFORE
+
+const obj = { a: 0, b: 1 };
+Object.assign(obj, { c: 2 });
+someFunc(obj.c); // Property 'c' does not exist on type '{ a: number; b: number; }'
+```
+
+```ts
+// AFTER
+
+const obj = { a: 0, b: 1 };
+Object.assign(obj, { c: 2 });
+someFunc(obj.c); // It knows that 'c' has been added.
+```
+
 ## Rules we won't add
 
 ### `Object.keys`/`Object.entries`

--- a/src/entrypoints/object-assign.d.ts
+++ b/src/entrypoints/object-assign.d.ts
@@ -1,0 +1,3 @@
+interface Object {
+  assign<T, S>(target: T, source: S): asserts target is T & S;
+}

--- a/src/tests/object-assign.ts
+++ b/src/tests/object-assign.ts
@@ -1,0 +1,18 @@
+import { doNotExecute, Equal, Expect } from "./utils";
+
+doNotExecute(() => {
+  const obj = { a: 0, b: 1 };
+  Object.assign(obj, { c: 2 }); // Typescript now knows that c is available.
+  type Obj = [
+    Expect<
+      Equal<
+        typeof obj,
+        {
+          a: number;
+          b: number;
+          c: number;
+        }
+      >
+    >
+  ];
+});


### PR DESCRIPTION
So, I know you have flagged Object.keys and entries as "will not do", but I figured that Object.assign wasn't included in that, so... Introducing, the new and improved Object.assign, which now asserts that the target is the sum of both the target and the source! 


```ts
// BEFORE

const obj = { a: 0, b: 1 };
Object.assign(obj, { c: 2 });
someFunc(obj.c); // Property 'c' does not exist on type '{ a: number; b: number; }'
```

```ts
// AFTER

const obj = { a: 0, b: 1 };
Object.assign(obj, { c: 2 });
someFunc(obj.c); // It knows that 'c' has been added.
```
