### PR TITLE
Fixes to isArray, handled when input is `any`

### DIFF
--- a/src/entrypoints/is-array.d.ts
+++ b/src/entrypoints/is-array.d.ts
@@ -1,3 +1,12 @@
+type AsArray<T> = T[] extends T ? T[] : any[] 
+/* 
+  The reason I'm using a separate type here called AsArray
+  In cases of "Unarray Test" the type looks confusing like: T & (T[] extends T ? T & T[] : any[])
+  With AsArray it at least looks like this: T & AsArray<T>
+    which is a lot more readable.
+  
+  In other cases it just shows unknown[], any[] or string[] etc as normal.
+*/ 
 interface ArrayConstructor {
-  isArray(arg: any): arg is unknown[];
+  isArray<T>(arg: T | T[]): arg is AsArray<T>
 }

--- a/src/entrypoints/is-array.d.ts
+++ b/src/entrypoints/is-array.d.ts
@@ -1,12 +1,3 @@
-type AsArray<T> = T[] extends T ? T[] : any[] 
-/* 
-  The reason I'm using a separate type here called AsArray
-  In cases of "Unarray Test" the type looks confusing like: T & (T[] extends T ? T & T[] : any[])
-  With AsArray it at least looks like this: T & AsArray<T>
-    which is a lot more readable.
-  
-  In other cases it just shows unknown[], any[] or string[] etc as normal.
-*/ 
 interface ArrayConstructor {
-  isArray<T>(arg: T | T[]): arg is AsArray<T>
+  isArray<T>(arg: T | T[]): arg is T[] extends T ? T[] : any[] 
 }

--- a/src/entrypoints/is-array.d.ts
+++ b/src/entrypoints/is-array.d.ts
@@ -1,4 +1,3 @@
 interface ArrayConstructor {
-  // @ts-ignore
-  isArray<T>(arg: T[] extends T ? T | T[] : never): arg is unknown[];
+  isArray<T>(arg: T[] extends T ? T | T[] : never): arg is T[] extends T ? T[] : never;
 }

--- a/src/entrypoints/is-array.d.ts
+++ b/src/entrypoints/is-array.d.ts
@@ -1,3 +1,4 @@
 interface ArrayConstructor {
-  isArray<T>(arg: T | T[]): arg is T[] extends T ? T[] : any[] 
+  // @ts-ignore
+  isArray<T>(arg: T[] extends T ? T | T[] : never): arg is unknown[];
 }

--- a/src/tests/is-array.ts
+++ b/src/tests/is-array.ts
@@ -1,7 +1,7 @@
 import { doNotExecute, Equal, Expect } from "./utils";
 
 doNotExecute(() => {
-  const maybeArr = [1, 2, 3] as unknown
+  const maybeArr = [1, 2, 3] as unknown;
 
   if (Array.isArray(maybeArr)) {
     type tests = [Expect<Equal<typeof maybeArr, unknown[]>>];
@@ -9,7 +9,7 @@ doNotExecute(() => {
 });
 
 doNotExecute(() => {
-  const maybeArr = [1, 2, 3] as any
+  const maybeArr = [1, 2, 3] as any;
 
   if (Array.isArray(maybeArr)) {
     type tests = [Expect<Equal<typeof maybeArr, any[]>>];
@@ -32,15 +32,10 @@ doNotExecute(() => {
   type tests = [Expect<Equal<typeof paths, string[]>>];
 });
 
-// Unarray Test
 doNotExecute(() => {
-  type Unarray<T> = T extends Array<infer U> ? U : T;
-
   function test<T>(value: T) {
-	
-	  const inner = <X extends Unarray<T>>(v: X[]) => {
-		  // 
-	  }
+    type Unarray<T> = T extends Array<infer U> ? U : T;
+	  const inner = <X extends Unarray<T>>(v: X[]) => {}
 	
 	  if (Array.isArray(value)) {
 		  inner(value);

--- a/src/tests/is-array.ts
+++ b/src/tests/is-array.ts
@@ -9,10 +9,26 @@ doNotExecute(() => {
 });
 
 doNotExecute(() => {
+  const maybeArr = [1, 2, 3] as unknown[];
+
+  if (Array.isArray(maybeArr)) {
+    type tests = [Expect<Equal<typeof maybeArr, unknown[]>>];
+  }
+});
+
+doNotExecute(() => {
   const maybeArr = [1, 2, 3] as any;
 
   if (Array.isArray(maybeArr)) {
-    type tests = [Expect<Equal<typeof maybeArr, any[]>>];
+    type tests = [Expect<Equal<typeof maybeArr, unknown[]>>];
+  }
+});
+
+doNotExecute(() => {
+  const maybeArr = [1, 2, 3] as any[];
+
+  if (Array.isArray(maybeArr)) {
+    type tests = [Expect<Equal<typeof maybeArr, unknown[]>>];
   }
 });
 
@@ -25,7 +41,22 @@ doNotExecute(() => {
 });
 
 doNotExecute(() => {
-  let path: string | string[] = [];
+  const arrOrString = [] as string[] | string;
+
+  if (Array.isArray(arrOrString)) return;
+  type tests = [Expect<Equal<typeof arrOrString, string>>];
+});
+
+doNotExecute(() => {
+  let arrOrString = "" as string | [1, 2];
+
+  if (Array.isArray(arrOrString)) {
+    type tests = [Expect<Equal<typeof arrOrString, [1, 2]>>];
+  }
+});
+
+doNotExecute(() => {
+  let path = [] as string | string[];
 
   const paths = Array.isArray(path) ? path : [path];
 
@@ -35,10 +66,10 @@ doNotExecute(() => {
 doNotExecute(() => {
   function test<T>(value: T) {
     type Unarray<T> = T extends Array<infer U> ? U : T;
-	  const inner = <X extends Unarray<T>>(v: X[]) => {}
-	
-	  if (Array.isArray(value)) {
-		  inner(value);
-	  }
+    const inner = <X extends Unarray<T>>(v: X[]) => {};
+
+    if (Array.isArray(value)) {
+      inner(value);
+    }
   }
 });

--- a/src/tests/is-array.ts
+++ b/src/tests/is-array.ts
@@ -1,10 +1,18 @@
 import { doNotExecute, Equal, Expect } from "./utils";
 
 doNotExecute(() => {
-  const maybeArr = [1, 2, 3] as unknown;
+  const maybeArr = [1, 2, 3] as unknown
 
   if (Array.isArray(maybeArr)) {
     type tests = [Expect<Equal<typeof maybeArr, unknown[]>>];
+  }
+});
+
+doNotExecute(() => {
+  const maybeArr = [1, 2, 3] as any
+
+  if (Array.isArray(maybeArr)) {
+    type tests = [Expect<Equal<typeof maybeArr, any[]>>];
   }
 });
 
@@ -22,4 +30,20 @@ doNotExecute(() => {
   const paths = Array.isArray(path) ? path : [path];
 
   type tests = [Expect<Equal<typeof paths, string[]>>];
+});
+
+// Unarray Test
+doNotExecute(() => {
+  type Unarray<T> = T extends Array<infer U> ? U : T;
+
+  function test<T>(value: T) {
+	
+	  const inner = <X extends Unarray<T>>(v: X[]) => {
+		  // 
+	  }
+	
+	  if (Array.isArray(value)) {
+		  inner(value);
+	  }
+  }
 });

--- a/src/tests/is-array.ts
+++ b/src/tests/is-array.ts
@@ -20,7 +20,7 @@ doNotExecute(() => {
   const maybeArr = [1, 2, 3] as any;
 
   if (Array.isArray(maybeArr)) {
-    type tests = [Expect<Equal<typeof maybeArr, unknown[]>>];
+    type tests = [Expect<Equal<typeof maybeArr, any[]>>];
   }
 });
 
@@ -28,7 +28,7 @@ doNotExecute(() => {
   const maybeArr = [1, 2, 3] as any[];
 
   if (Array.isArray(maybeArr)) {
-    type tests = [Expect<Equal<typeof maybeArr, unknown[]>>];
+    type tests = [Expect<Equal<typeof maybeArr, any[]>>];
   }
 });
 


### PR DESCRIPTION
Handled the cases when the input is `any[]` or `any` and not `unknown` or `unknown[]`
https://github.com/total-typescript/ts-reset/issues/48#issuecomment-1440269813

You might wanna check if the test are correct.