### PR TITLE
feat: override require return type to unknown

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,11 @@
       "types": "./dist/utils.d.ts",
       "import": "./dist/utils.mjs",
       "default": "./dist/utils.js"
+    },
+    "./require": {
+      "types": "./dist/require.d.ts",
+      "import": "./dist/require.mjs",
+      "default": "./dist/require.js"
     }
   },
   "keywords": [],

--- a/src/entrypoints/recommended.d.ts
+++ b/src/entrypoints/recommended.d.ts
@@ -2,5 +2,6 @@
 /// <reference path="filter-boolean.d.ts" />
 /// <reference path="is-array.d.ts" />
 /// <reference path="json-parse.d.ts" />
+/// <reference path="require.d.ts" />
 /// <reference path="array-includes.d.ts" />
 /// <reference path="set-has.d.ts" />

--- a/src/entrypoints/require.d.ts
+++ b/src/entrypoints/require.d.ts
@@ -1,0 +1,3 @@
+interface NodeRequire {
+  (id: string): unknown;
+}

--- a/src/tests/require.ts
+++ b/src/tests/require.ts
@@ -1,0 +1,7 @@
+import { doNotExecute, Equal, Expect } from "./utils";
+
+doNotExecute(() => {
+  const result = require("test");
+
+  type tests = [Expect<Equal<typeof result, unknown>>];
+});


### PR DESCRIPTION
Resolves issue #55 

Overrides dynamic require's return type from `any` to `unknown`.

there may be a better way of overriding the NodeRequire interface which doesn't result in the `(+1 overload)` message (see image below) but my typescript knowledge isn't deep enough to come up with one! Fedback appreciated

<img width="280" alt="image" src="https://user-images.githubusercontent.com/47698091/220724703-8c0fce04-6aa1-48a4-ae22-a46e84caf2c6.png">


