### PR TITLE
Started new-array unknown type, caught in `prototype`

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,11 @@
       "types": "./dist/utils.d.ts",
       "import": "./dist/utils.mjs",
       "default": "./dist/utils.js"
+    },
+    "./new-array": {
+      "types": "./dist/new-array.d.ts",
+      "import": "./dist/new-array.mjs",
+      "default": "./dist/new-array.js"
     }
   },
   "keywords": [],

--- a/readme.md
+++ b/readme.md
@@ -262,6 +262,18 @@ const validate = (input: unknown) => {
 };
 ```
 
+### Make `new Array()` return `unknown[]`
+
+With `new Array()` you can introduce `any`'s into your code:
+
+```ts
+import "@total-typescript/ts-reset/new-array";
+
+const arr = new Array(); // unknown[]
+
+const arr2 = []; // unknown[]
+```
+
 ## Rules we won't add
 
 ### `Object.keys`/`Object.entries`

--- a/src/entrypoints/new-array.d.ts
+++ b/src/entrypoints/new-array.d.ts
@@ -1,0 +1,18 @@
+interface ArrayConstructor {
+  new (arrayLength?: number): unknown[];
+  (arrayLength?: number): unknown[];
+
+  // not sure if the following is needed:
+  // new <T>(arrayLength: number): T[];
+  // new <T>(...items: T[]): T[];
+  // <T>(arrayLength: number): T[];
+  // <T>(...items: T[]): T[];
+  // readonly prototype: unknown[];
+
+  // following only works with `export` or `export declare` prefixed.
+  // readonly prototype: unknown[];
+}
+
+interface Array<T> {
+  readonly prototype: unknown[];
+}

--- a/src/entrypoints/recommended.d.ts
+++ b/src/entrypoints/recommended.d.ts
@@ -4,3 +4,4 @@
 /// <reference path="json-parse.d.ts" />
 /// <reference path="array-includes.d.ts" />
 /// <reference path="set-has.d.ts" />
+/// <reference path="new-array.d.ts" />

--- a/src/tests/new-array.ts
+++ b/src/tests/new-array.ts
@@ -1,0 +1,14 @@
+import { doNotExecute, Equal, Expect } from "./utils";
+
+// check that new array is inferred correctly to unknown[]
+doNotExecute(() => {
+  const unknownArr = new Array();
+
+  type tests = [Expect<Equal<typeof unknownArr, unknown[]>>];
+});
+
+doNotExecute(() => {
+  // appears to be any[] instead of unknown[]
+  // const alsoUnkownArr = [];
+  // type tests = [Expect<Equal<typeof alsoUnkownArr, unknown[]>>];
+});


### PR DESCRIPTION
This is an idea I had, couldn't get the `const arr = []` to work.