### PR TITLE
Add monorepo instructions to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,23 @@ import "@total-typescript/ts-reset";
 
 3. Enjoy improved typings across your _entire_ project.
 
+## Get Started (Monorepo)
+
+1. Install: `npm i -D @total-typescript/ts-reset` to your root package.json
+
+2. Create a `reset.d.ts` file in the root of your project:
+
+```ts
+import "@total-typescript/ts-reset";
+```
+
+3. In your individual packages `tsconfig.json`, add the relative path from your package to the `reset.d.ts` file
+```json
+"include": [
+    "../../reset.d.ts",
+  ]
+```
+
 ### Installing only certain rules
 
 By importing from `@total-typescript/ts-reset`, you're bundling _all_ the recommended rules.


### PR DESCRIPTION
Just setup ts-reset for my monorepo and found this was the most painless way to do it, updated the README to reflect how I set this up for my monorepo, this allows you to only install it once into the root package json