### PR TITLE
feat(json-parse): allow JSON.parse() to be generic

### DIFF
--- a/src/entrypoints/json-parse.d.ts
+++ b/src/entrypoints/json-parse.d.ts
@@ -5,8 +5,8 @@ interface JSON {
    * @param reviver A function that transforms the results. This function is called for each member of the object.
    * If a member contains nested objects, the nested objects are transformed before the parent object is.
    */
-  parse(
+  parse<Output = unknown>(
     text: string,
     reviver?: (this: any, key: string, value: any) => any,
-  ): unknown;
+  ): Output;
 }


### PR DESCRIPTION
Sometimes we know what kind of data we're working on, in such case we should be able to do `const car = JSON.parse<Car>(carJson)`