### PR TITLE
Adds widened has support to ReadonlySet

### DIFF
--- a/.changeset/nine-lies-mix.md
+++ b/.changeset/nine-lies-mix.md
@@ -1,5 +1,5 @@
 ---
-"@total-typescript/ts-reset": minor
+"@total-typescript/ts-reset": patch
 ---
 
-Adds widened has support to ReadonlySet
+Fixed an oversight with the initial `set-has` implementation by adding support to `ReadonlySet`.

--- a/.changeset/nine-lies-mix.md
+++ b/.changeset/nine-lies-mix.md
@@ -1,0 +1,5 @@
+---
+"@total-typescript/ts-reset": minor
+---
+
+Adds widened has support to ReadonlySet

--- a/src/entrypoints/set-has.d.ts
+++ b/src/entrypoints/set-has.d.ts
@@ -3,3 +3,7 @@
 interface Set<T> {
   has(value: T | (TSReset.WidenLiteral<T> & {})): boolean;
 }
+
+interface ReadonlySet<T> {
+  has(value: T | (TSReset.WidenLiteral<T> & {})): boolean;
+}

--- a/src/tests/set-has.ts
+++ b/src/tests/set-has.ts
@@ -15,3 +15,19 @@ doNotExecute(() => {
     true,
   );
 });
+
+doNotExecute(() => {
+  const set = new Set([1, 2, 3] as const) as ReadonlySet<1 | 2 | 3>;
+
+  set.has(4);
+
+  set.has(
+    // @ts-expect-error
+    "4",
+  );
+
+  set.has(
+    // @ts-expect-error
+    true,
+  );
+});


### PR DESCRIPTION
Currently only `Set` has support for the widened `has` and if someone would use `ReadonlySet` they would lose this widening. 

With this change `ReadonlySet` now supports the widened `has` argument.

I added it directly to the `set-has` rule to be similair to the handling in `array-includes`

I assume this should apply to `WeakSet` as well - if wanted I can add it as well.