### PR TITLE
[ReadonlyArray] Add types for `.at()`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -262,6 +262,33 @@ const validate = (input: unknown) => {
 };
 ```
 
+### Make `.at()` on `as const` arrays more smart
+
+```ts
+import "@total-typescript/ts-reset/array-at";
+```
+
+When you're using `.at()` on a tuple, you lose the specificity of your array's type
+
+```ts
+// BEFORE
+
+const array = [false, 1, "2"] as const
+const first = array.at(0) // false | 1 | "2" | undefined
+const last = array.at(-1) // false | 1 | "2" | undefined
+```
+
+With `array-at` enabled, you keep the type of the specific index you're accessing:
+
+```ts
+// AFTER
+import "@total-typescript/ts-reset/array-at";
+
+const array = [false, 1, "2"] as const
+const first = array.at(0) // false
+const last = array.at(-1) // "2"
+```
+
 ## Rules we won't add
 
 ### `Object.keys`/`Object.entries`

--- a/src/entrypoints/array-at.d.ts
+++ b/src/entrypoints/array-at.d.ts
@@ -1,0 +1,13 @@
+/// <reference path="utils.d.ts" />
+
+interface ReadonlyArray<T> {
+	/**
+	 * Returns the item located at the specified index.
+	 * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
+	 */
+	at<I extends number> (index: I): `${I}` extends `-${infer J extends number}`
+		? `${TSReset.Subtract<this["length"], J>}` extends `-${number}`
+			? undefined
+			: this[TSReset.Subtract<this["length"], J>]
+		: this[I]
+}

--- a/src/entrypoints/utils.d.ts
+++ b/src/entrypoints/utils.d.ts
@@ -14,4 +14,16 @@ declare namespace TSReset {
     : T extends symbol
     ? symbol
     : T;
+
+  type Length<T extends any[]> = T extends { length: infer L }
+    ? L
+    : never
+
+  type BuildTuple<L extends number, T extends any[] = []> = T extends { length: L }
+    ? T
+    : BuildTuple<L, [...T, any]>
+  
+  type Subtract<A extends number, B extends number> = BuildTuple<A> extends [...(infer U), ...BuildTuple<B>]
+    ? Length<U>
+    : never
 }

--- a/src/tests/array-at.ts
+++ b/src/tests/array-at.ts
@@ -1,0 +1,31 @@
+import { doNotExecute, Equal, Expect } from "./utils";
+
+doNotExecute(async () => {
+  const arr = [false, 1, '2'] as const;
+
+  const a = arr.at(0)
+  const b = arr.at(1)
+  const c = arr.at(2)
+  const d = arr.at(3)
+  type tests = [
+    Expect<Equal<typeof a, false>>,
+    Expect<Equal<typeof b, 1>>,
+    Expect<Equal<typeof c, '2'>>,
+    Expect<Equal<typeof d, undefined>>,
+  ]
+});
+
+doNotExecute(async () => {
+  const arr = [false, 1, '2'] as const;
+
+  const a = arr.at(-1)
+  const b = arr.at(-2)
+  const c = arr.at(-3)
+  const d = arr.at(-4)
+  type tests = [
+    Expect<Equal<typeof a, '2'>>,
+    Expect<Equal<typeof b, 1>>,
+    Expect<Equal<typeof c, false>>,
+    Expect<Equal<typeof d, undefined>>,
+  ]
+});


### PR DESCRIPTION
This PR fixes https://github.com/total-typescript/ts-reset/issues/100

See issue for a more complete description