### PR TITLE
improve types for `String.split`

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,11 @@
       "types": "./dist/array-index-of.d.ts",
       "import": "./dist/array-index-of.mjs",
       "default": "./dist/array-index-of.js"
+    },
+    "./string-split": {
+      "types": "./dist/string-split.d.ts",
+      "import": "./dist/string-split.mjs",
+      "default": "./dist/string-split.js"
     }
   },
   "keywords": [],

--- a/src/entrypoints/recommended.d.ts
+++ b/src/entrypoints/recommended.d.ts
@@ -6,3 +6,4 @@
 /// <reference path="set-has.d.ts" />
 /// <reference path="map-has.d.ts" />
 /// <reference path="array-index-of.d.ts" />
+/// <reference path="string-split.d.ts" />

--- a/src/entrypoints/string-split.d.ts
+++ b/src/entrypoints/string-split.d.ts
@@ -1,0 +1,5 @@
+interface String {
+	split<Splitter extends string, Limit extends number>(string: Splitter, limit?: Limit): Limit extends 0 ? []
+		: Splitter extends '' ? string[]
+		: [string, ...string[]]
+}

--- a/src/entrypoints/string-split.d.ts
+++ b/src/entrypoints/string-split.d.ts
@@ -1,5 +1,5 @@
 interface String {
-	split<Splitter extends string, Limit extends number>(string: Splitter, limit?: Limit): Limit extends 0 ? []
-		: Splitter extends '' ? string[]
+	split<Separator extends string, Limit extends number>(separator: Separator, limit?: Limit): Limit extends 0 ? []
+		: Separator extends '' ? string[]
 		: [string, ...string[]]
 }

--- a/src/tests/string-split.ts
+++ b/src/tests/string-split.ts
@@ -1,0 +1,43 @@
+
+import { doNotExecute, Equal, Expect } from "./utils";
+
+doNotExecute(() => {
+	const result = ''.split('')
+	type tests = [Expect<Equal<typeof result, string[]>>];
+});
+
+doNotExecute(() => {
+	const result = ''.split('')[0]
+
+	type tests = [Expect<Equal<typeof result, string | undefined>>];
+});
+
+doNotExecute(() => {
+	const result = 'value'.split('test')
+
+	type tests = [Expect<Equal<typeof result, [string, ...string[]]>>];
+});
+
+doNotExecute(() => {
+	const result = 'value'.split('test')[0]
+
+	type tests = [Expect<Equal<typeof result, string>>];
+});
+
+doNotExecute(() => {
+	const result = 'value'.split('test')[1]
+
+	type tests = [Expect<Equal<typeof result, string | undefined>>];
+});
+
+doNotExecute(() => {
+	const result = 'value'.split('test', 0)
+
+	type tests = [Expect<Equal<typeof result, []>>];
+});
+
+doNotExecute(() => {
+	const result = 'value'.split('test', 1)
+
+	type tests = [Expect<Equal<typeof result, [string, ...string[]]>>];
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
     "strict": true, /* Enable all strict type-checking options. */
+    "noUncheckedIndexedAccess": true, /* Add undefined to a type when accessed using an index. */
   },
   "exclude": [
     "dist",


### PR DESCRIPTION
This PR improves the type definitions for `String.split`. By default it always returns `string[]` but depending on the arguments passed, we can infer a few cases e.g.
 - Splitting a string will almost always return an array with at least one item, so the type `[string, ...string[]]` makes more sense.
 - Unless when the string and separator is an empty string `''`, then an empty array `[]` is returned. In that case `string[]` makes sense again
 - When the limit is set to `0` an empty array `[]` gets returned.