### PR TITLE
Typed the error param of `Promise.catch` as `unknown`

### DIFF
--- a/.changeset/rotten-meals-remember.md
+++ b/.changeset/rotten-meals-remember.md
@@ -1,0 +1,5 @@
+---
+"@total-typescript/ts-reset": minor
+---
+
+Typed the error/reject parameter of Promise.catch as unknown instead of any

--- a/package.json
+++ b/package.json
@@ -72,6 +72,11 @@
       "types": "./dist/array-index-of.d.ts",
       "import": "./dist/array-index-of.mjs",
       "default": "./dist/array-index-of.js"
+    },
+    "./promise-catch": {
+      "types": "./dist/promise-catch.d.ts",
+      "import": "./dist/promise-catch.mjs",
+      "default": "./dist/promise-catch.js"
     }
   },
   "keywords": [],

--- a/src/entrypoints/promise-catch.d.ts
+++ b/src/entrypoints/promise-catch.d.ts
@@ -1,0 +1,10 @@
+/// <reference path="utils.d.ts" />
+
+interface Promise<T> {
+  catch<TResult = never>(
+    onrejected?:
+      | ((reason: unknown) => TResult | PromiseLike<TResult>)
+      | undefined
+      | null,
+  ): Promise<T | TResult>;
+}

--- a/src/entrypoints/recommended.d.ts
+++ b/src/entrypoints/recommended.d.ts
@@ -6,3 +6,4 @@
 /// <reference path="set-has.d.ts" />
 /// <reference path="map-has.d.ts" />
 /// <reference path="array-index-of.d.ts" />
+/// <reference path="promise-catch.d.ts" />

--- a/src/tests/promise-catch.ts
+++ b/src/tests/promise-catch.ts
@@ -1,0 +1,7 @@
+import { doNotExecute, Equal, Expect } from "./utils";
+
+doNotExecute(() => {
+  Promise.resolve().catch((err) => {
+    type tests = [Expect<Equal<typeof err, unknown>>];
+  });
+});


### PR DESCRIPTION
When using try...catch in strict mode (or with the `useUnknownInCatchVariables` tsconfig flag enabled) the type of `error` is `unknown`
```ts
try {} catch (error) {}
//            ^? error: unknown
```

However when working with promises, the type of a caught `error` is `any`
```ts
Promise.resolve().catch((error) => {});
//                       ^? error: any
```

This PR changes the type of `error` to `unknown` for consistency (and type safety)
```ts
Promise.resolve().catch((error) => {});
//                       ^? error: unknown
```