### PR TITLE
Number.isFinite should assert the value is number

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,11 @@
       "types": "./dist/array-index-of.d.ts",
       "import": "./dist/array-index-of.mjs",
       "default": "./dist/array-index-of.js"
+    },
+    "./is-finite": {
+      "types": "./dist/is-finite.d.ts",
+      "import": "./dist/is-finite.mjs",
+      "default": "./dist/is-finite.js"
     }
   },
   "keywords": [],

--- a/readme.md
+++ b/readme.md
@@ -293,6 +293,40 @@ const validate = (input: unknown) => {
 };
 ```
 
+### Making Number.isFinite assert number
+
+Currently `Number.isFinite` makes no assertion at the TypeScript level that the passed value is a number, even though it does actually assert this:
+
+```ts
+// BEFORE
+import "@total-typescript/ts-reset/is-finite";
+
+const validate = (input: unknown) => {
+    if (Number.isFinite(input)) {
+        console.log(input); // unknown
+    }
+
+    // the workaround
+    if (typeof input === "number" && Number.isFinite(input)) {
+        console.log(input); // number
+    }
+}
+```
+
+With `is-finite` enabled, this now happens as you would expect:
+
+```ts
+// AFTER
+import "@total-typescript/ts-reset/is-finite";
+
+const validate = (input: unknown) => {
+    // yay!
+    if (Number.isFinite(input)) {
+        console.log(input); // number
+    }
+}
+```
+
 ## Rules we won't add
 
 ### `Object.keys`/`Object.entries`

--- a/src/entrypoints/is-finite.d.ts
+++ b/src/entrypoints/is-finite.d.ts
@@ -1,0 +1,3 @@
+interface NumberConstructor {
+    isFinite(number: unknown): number is number;
+}

--- a/src/entrypoints/recommended.d.ts
+++ b/src/entrypoints/recommended.d.ts
@@ -6,3 +6,4 @@
 /// <reference path="set-has.d.ts" />
 /// <reference path="map-has.d.ts" />
 /// <reference path="array-index-of.d.ts" />
+/// <reference path="is-finite.d.ts" />

--- a/src/tests/is-finite.ts
+++ b/src/tests/is-finite.ts
@@ -1,0 +1,9 @@
+import { doNotExecute, Equal, Expect } from "./utils";
+
+doNotExecute(() => {
+  const maybeNum = 1 as unknown;
+
+  if (Number.isFinite(maybeNum)) {
+    type tests = [Expect<Equal<typeof maybeNum, number>>];
+  }
+});


### PR DESCRIPTION
```
The Number.isFinite() method determines whether the passed value is a finite number — that is, it checks that the type of a given value is Number, and the number is neither positive Infinity, negative Infinity, nor Na
```
- JSDoc for isFinite

This PR changes isFinite to a type guard for `number`. Prevents workarounds:

```ts
function myFunction(value: unknown) {
  // typeof value === number is redundant here, but required for TS
  if (typeof value === "number" && Number.isFinite(value)) {
    console.log(value); // number
  }
}
```

Please be nitpicky about the README changes.

Also, the similar functions `isInteger`, `isSafeInteger`, and `isNan` (not sure about the last one) also have the same issue that could be fixed. I'm hesitant to add them all in one go, though.