### PR TITLE
✨ Use `JsonValue` instead of `unknown`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
       "import": "./dist/json-parse.mjs",
       "default": "./dist/json-parse.js"
     },
+    "./json": {
+      "types": "./dist/json.d.ts",
+      "import": "./dist/json.mjs",
+      "default": "./dist/json.js"
+    },
     "./fetch": {
       "types": "./dist/fetch.d.ts",
       "import": "./dist/fetch.mjs",

--- a/readme.md
+++ b/readme.md
@@ -42,10 +42,10 @@ fetch("/")
 
 2. Create a `reset.d.ts` file in your project with these contents:
 
-```ts
-// Do not add any other lines of code to this file!
-import "@total-typescript/ts-reset";
-```
+   ```ts
+   // Do not add any other lines of code to this file!
+   import "@total-typescript/ts-reset";
+   ```
 
 3. Enjoy improved typings across your _entire_ project.
 

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ TypeScript's built-in typings are not perfect. `ts-reset` makes them better.
 
 **With `ts-reset`**:
 
-- 👍 `.json` (in `fetch`) and `JSON.parse` both return `unknown`
+- 👍 `.json` (in `fetch`) and `JSON.parse` both return `JsonValue`
 - ✅ `.filter(Boolean)` behaves EXACTLY how you expect
 - 🥹 `array.includes` is widened to be more ergonomic
 - 🚀 And several more changes!
@@ -27,12 +27,12 @@ import "@total-typescript/ts-reset";
 const filteredArray = [1, 2, undefined].filter(Boolean); // number[]
 
 // Get rid of the any's in JSON.parse and fetch
-const result = JSON.parse("{}"); // unknown
+const result = JSON.parse("{}"); // JsonValue
 
 fetch("/")
   .then((res) => res.json())
   .then((json) => {
-    console.log(json); // unknown
+    console.log(json); // JsonValue
   });
 ```
 
@@ -56,10 +56,10 @@ By importing from `@total-typescript/ts-reset`, you're bundling _all_ the recomm
 To only import the rules you want, you can import like so:
 
 ```ts
-// Makes JSON.parse return unknown
+// Makes JSON.parse return JsonValue
 import "@total-typescript/ts-reset/json-parse";
 
-// Makes await fetch().then(res => res.json()) return unknown
+// Makes await fetch().then(res => res.json()) return JsonValue
 import "@total-typescript/ts-reset/fetch";
 ```
 
@@ -75,7 +75,7 @@ Below is a full list of all the rules available.
 
 ## Rules
 
-### Make `JSON.parse` return `unknown`
+### Make `JSON.parse` return `JsonValue`
 
 ```ts
 import "@total-typescript/ts-reset/json-parse";
@@ -88,16 +88,16 @@ import "@total-typescript/ts-reset/json-parse";
 const result = JSON.parse("{}"); // any
 ```
 
-By changing the result of `JSON.parse` to `unknown`, we're now forced to either validate the `unknown` to ensure it's the correct type (perhaps using [`zod`](https://github.com/colinhacks/zod)), or cast it with `as`.
+By changing the result of `JSON.parse` to `JsonValue`, we're now forced to either validate the `JsonValue` to ensure it's the correct type (perhaps using [`zod`](https://github.com/colinhacks/zod)), or cast it with `as`.
 
 ```ts
 // AFTER
 import "@total-typescript/ts-reset/json-parse";
 
-const result = JSON.parse("{}"); // unknown
+const result = JSON.parse("{}"); // JsonValue
 ```
 
-### Make `.json()` return `unknown`
+### Make `.json()` return `JsonValue`
 
 ```ts
 import "@total-typescript/ts-reset/fetch";
@@ -114,7 +114,7 @@ fetch("/")
   });
 ```
 
-By forcing `res.json` to return `unknown`, we're encouraged to distrust its results, making us more likely to validate the results of `fetch`.
+By forcing `res.json` to return `JsonValue`, we're encouraged to distrust its results, making us more likely to validate the results of `fetch`.
 
 ```ts
 // AFTER
@@ -123,7 +123,7 @@ import "@total-typescript/ts-reset/fetch";
 fetch("/")
   .then((res) => res.json())
   .then((json) => {
-    console.log(json); // unknown
+    console.log(json); // JsonValue
   });
 ```
 

--- a/src/entrypoints/fetch.d.ts
+++ b/src/entrypoints/fetch.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="utils.d.ts" />
+/// <reference path="json.d.ts" />
 
 interface Body {
   json(): Promise<TSReset.JsonValue>;

--- a/src/entrypoints/fetch.d.ts
+++ b/src/entrypoints/fetch.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="utils.d.ts" />
+
 interface Body {
-  json(): Promise<unknown>;
+  json(): Promise<TSReset.JsonValue>;
 }

--- a/src/entrypoints/json-parse.d.ts
+++ b/src/entrypoints/json-parse.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="utils.d.ts" />
+
 interface JSON {
   /**
    * Converts a JavaScript Object Notation (JSON) string into an object.
@@ -8,5 +10,5 @@ interface JSON {
   parse(
     text: string,
     reviver?: (this: any, key: string, value: any) => any,
-  ): unknown;
+  ): TSReset.JsonValue;
 }

--- a/src/entrypoints/json-parse.d.ts
+++ b/src/entrypoints/json-parse.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="utils.d.ts" />
+/// <reference path="json.d.ts" />
 
 interface JSON {
   /**

--- a/src/entrypoints/json.d.ts
+++ b/src/entrypoints/json.d.ts
@@ -1,0 +1,5 @@
+declare namespace TSReset {
+  type JsonValue = string | number | boolean | JsonValue[] | JsonObject | null;
+
+  type JsonObject = { [key: string]: JsonValue };
+}

--- a/src/entrypoints/json.d.ts
+++ b/src/entrypoints/json.d.ts
@@ -1,5 +1,5 @@
 declare namespace TSReset {
-  type JsonValue = string | number | boolean | JsonValue[] | JsonObject | null;
+  type JsonValue = string | number | boolean | JsonObject | JsonValue[] | null;
 
   type JsonObject = { [key: string]: JsonValue };
 }

--- a/src/entrypoints/utils.d.ts
+++ b/src/entrypoints/utils.d.ts
@@ -1,4 +1,8 @@
 declare namespace TSReset {
+  type JsonValue = string | number | boolean | JsonValue[] | JsonObject | null;
+
+  type JsonObject = { [key: string]: JsonValue };
+
   type NonFalsy<T> = T extends false | 0 | "" | null | undefined | 0n
     ? never
     : T;

--- a/src/entrypoints/utils.d.ts
+++ b/src/entrypoints/utils.d.ts
@@ -1,8 +1,4 @@
 declare namespace TSReset {
-  type JsonValue = string | number | boolean | JsonValue[] | JsonObject | null;
-
-  type JsonObject = { [key: string]: JsonValue };
-
   type NonFalsy<T> = T extends false | 0 | "" | null | undefined | 0n
     ? never
     : T;

--- a/src/tests/fetch.ts
+++ b/src/tests/fetch.ts
@@ -3,7 +3,7 @@ import { doNotExecute, Equal, Expect } from "./utils";
 doNotExecute(async () => {
   const result = await fetch("/").then((res) => res.json());
 
-  type tests = [Expect<Equal<typeof result, unknown>>];
+  type tests = [Expect<Equal<typeof result, TSReset.JsonValue>>];
 });
 
 doNotExecute(async () => {

--- a/src/tests/json-parse.ts
+++ b/src/tests/json-parse.ts
@@ -3,7 +3,7 @@ import { doNotExecute, Equal, Expect } from "./utils";
 doNotExecute(() => {
   const result = JSON.parse("{}");
 
-  type tests = [Expect<Equal<typeof result, unknown>>];
+  type tests = [Expect<Equal<typeof result, TSReset.JsonValue>>];
 });
 
 doNotExecute(() => {


### PR DESCRIPTION
Both `JSON.parse` and `.json()` currently return `unknown`. This type is too general. We can use the more specific `JsonValue` type here. This allows users to consume the return value of these functions without having to use [`zod`](https://github.com/colinhacks/zod). However, users are still encouraged to validate and parse the result into another type since `JsonValue` is difficult to use.

```typescript
type JsonValue = string | number | boolean | JsonValue[] | JsonObject | null;

type JsonObject = { [key: string]: JsonValue };
```