### PR TITLE
💥 Add strong typing for `JSON.parse` when `reviver` is specified

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
       "import": "./dist/json-parse.mjs",
       "default": "./dist/json-parse.js"
     },
+    "./json": {
+      "types": "./dist/json.d.ts",
+      "import": "./dist/json.mjs",
+      "default": "./dist/json.js"
+    },
     "./fetch": {
       "types": "./dist/fetch.d.ts",
       "import": "./dist/fetch.mjs",

--- a/readme.md
+++ b/readme.md
@@ -316,29 +316,3 @@ const func: Func = () => {
 ```
 
 So, the only reasonable type for `Object.keys` to return is `Array<string>`.
-
-### Generics for `JSON.parse`, `Response.json` etc
-
-A common request is for `ts-reset` to add type arguments to functions like `JSON.parse`:
-
-```ts
-const str = JSON.parse<string>('"hello"');
-
-console.log(str); // string
-```
-
-This appears to improve the DX by giving you autocomplete on the thing that gets returned from `JSON.parse`.
-
-However, we argue that this is a lie to the compiler and so, unsafe.
-
-`JSON.parse` and `fetch` represent _validation boundaries_ - places where unknown data can enter your application code.
-
-If you _really_ know what data is coming back from a `JSON.parse`, then an `as` assertion feels like the right call:
-
-```ts
-const str = JSON.parse('"hello"') as string;
-
-console.log(str); // string
-```
-
-This provides the types you intend and also signals to the developer that this is _slightly_ unsafe.

--- a/readme.md
+++ b/readme.md
@@ -42,10 +42,10 @@ fetch("/")
 
 2. Create a `reset.d.ts` file in your project with these contents:
 
-```ts
-// Do not add any other lines of code to this file!
-import "@total-typescript/ts-reset";
-```
+   ```ts
+   // Do not add any other lines of code to this file!
+   import "@total-typescript/ts-reset";
+   ```
 
 3. Enjoy improved typings across your _entire_ project.
 

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ TypeScript's built-in typings are not perfect. `ts-reset` makes them better.
 
 **With `ts-reset`**:
 
-- 👍 `.json` (in `fetch`) and `JSON.parse` both return `unknown`
+- 👍 `.json` (in `fetch`) and `JSON.parse` both return `JsonValue`
 - ✅ `.filter(Boolean)` behaves EXACTLY how you expect
 - 🥹 `array.includes` is widened to be more ergonomic
 - 🚀 And several more changes!
@@ -27,12 +27,12 @@ import "@total-typescript/ts-reset";
 const filteredArray = [1, 2, undefined].filter(Boolean); // number[]
 
 // Get rid of the any's in JSON.parse and fetch
-const result = JSON.parse("{}"); // unknown
+const result = JSON.parse("{}"); // JsonValue
 
 fetch("/")
   .then((res) => res.json())
   .then((json) => {
-    console.log(json); // unknown
+    console.log(json); // JsonValue
   });
 ```
 
@@ -56,10 +56,10 @@ By importing from `@total-typescript/ts-reset`, you're bundling _all_ the recomm
 To only import the rules you want, you can import like so:
 
 ```ts
-// Makes JSON.parse return unknown
+// Makes JSON.parse return JsonValue
 import "@total-typescript/ts-reset/json-parse";
 
-// Makes await fetch().then(res => res.json()) return unknown
+// Makes await fetch().then(res => res.json()) return JsonValue
 import "@total-typescript/ts-reset/fetch";
 ```
 
@@ -75,7 +75,7 @@ Below is a full list of all the rules available.
 
 ## Rules
 
-### Make `JSON.parse` return `unknown`
+### Make `JSON.parse` return `JsonValue`
 
 ```ts
 import "@total-typescript/ts-reset/json-parse";
@@ -88,16 +88,16 @@ import "@total-typescript/ts-reset/json-parse";
 const result = JSON.parse("{}"); // any
 ```
 
-By changing the result of `JSON.parse` to `unknown`, we're now forced to either validate the `unknown` to ensure it's the correct type (perhaps using [`zod`](https://github.com/colinhacks/zod)), or cast it with `as`.
+By changing the result of `JSON.parse` to `JsonValue`, we're now forced to either validate the `JsonValue` to ensure it's the correct type (perhaps using [`zod`](https://github.com/colinhacks/zod)), or cast it with `as`.
 
 ```ts
 // AFTER
 import "@total-typescript/ts-reset/json-parse";
 
-const result = JSON.parse("{}"); // unknown
+const result = JSON.parse("{}"); // JsonValue
 ```
 
-### Make `.json()` return `unknown`
+### Make `.json()` return `JsonValue`
 
 ```ts
 import "@total-typescript/ts-reset/fetch";
@@ -114,7 +114,7 @@ fetch("/")
   });
 ```
 
-By forcing `res.json` to return `unknown`, we're encouraged to distrust its results, making us more likely to validate the results of `fetch`.
+By forcing `res.json` to return `JsonValue`, we're encouraged to distrust its results, making us more likely to validate the results of `fetch`.
 
 ```ts
 // AFTER
@@ -123,7 +123,7 @@ import "@total-typescript/ts-reset/fetch";
 fetch("/")
   .then((res) => res.json())
   .then((json) => {
-    console.log(json); // unknown
+    console.log(json); // JsonValue
   });
 ```
 

--- a/src/entrypoints/fetch.d.ts
+++ b/src/entrypoints/fetch.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="utils.d.ts" />
+/// <reference path="json.d.ts" />
 
 interface Body {
   json(): Promise<TSReset.JsonValue>;

--- a/src/entrypoints/fetch.d.ts
+++ b/src/entrypoints/fetch.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="utils.d.ts" />
+
 interface Body {
-  json(): Promise<unknown>;
+  json(): Promise<TSReset.JsonValue>;
 }

--- a/src/entrypoints/json-parse.d.ts
+++ b/src/entrypoints/json-parse.d.ts
@@ -4,11 +4,21 @@ interface JSON {
   /**
    * Converts a JavaScript Object Notation (JSON) string into an object.
    * @param text A valid JSON string.
+   */
+  parse(text: string): TSReset.JsonValue;
+
+  /**
+   * Converts a JavaScript Object Notation (JSON) string into an object.
+   * @param text A valid JSON string.
    * @param reviver A function that transforms the results. This function is called for each member of the object.
    * If a member contains nested objects, the nested objects are transformed before the parent object is.
    */
-  parse(
+  parse<A = unknown>(
     text: string,
-    reviver?: (this: any, key: string, value: any) => any,
-  ): TSReset.JsonValue;
+    reviver: <K extends string>(
+      this: TSReset.JsonHolder<K, A>,
+      key: K,
+      value: TSReset.JsonAlgebra<A>,
+    ) => A,
+  ): A;
 }

--- a/src/entrypoints/json-parse.d.ts
+++ b/src/entrypoints/json-parse.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="utils.d.ts" />
+
 interface JSON {
   /**
    * Converts a JavaScript Object Notation (JSON) string into an object.
@@ -8,5 +10,5 @@ interface JSON {
   parse(
     text: string,
     reviver?: (this: any, key: string, value: any) => any,
-  ): unknown;
+  ): TSReset.JsonValue;
 }

--- a/src/entrypoints/json-parse.d.ts
+++ b/src/entrypoints/json-parse.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="utils.d.ts" />
+/// <reference path="json.d.ts" />
 
 interface JSON {
   /**

--- a/src/entrypoints/json-parse.d.ts
+++ b/src/entrypoints/json-parse.d.ts
@@ -18,7 +18,7 @@ interface JSON {
     reviver: <K extends string>(
       this: TSReset.JsonHolder<K, A>,
       key: K,
-      value: TSReset.JsonAlgebra<A>,
+      value: TSReset.JsonValueF<A>,
     ) => A,
   ): A;
 }

--- a/src/entrypoints/json.d.ts
+++ b/src/entrypoints/json.d.ts
@@ -1,0 +1,5 @@
+declare namespace TSReset {
+  type JsonValue = string | number | boolean | JsonValue[] | JsonObject | null;
+
+  type JsonObject = { [key: string]: JsonValue };
+}

--- a/src/entrypoints/json.d.ts
+++ b/src/entrypoints/json.d.ts
@@ -3,11 +3,11 @@ declare namespace TSReset {
 
   type JsonComposite<A> = Record<string, A> | A[];
 
-  type JsonAlgebra<A> = JsonPrimitive | JsonComposite<A>;
+  type JsonValueF<A> = JsonPrimitive | JsonComposite<A>;
 
   type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
 
   type JsonObject = { [key: string]: JsonValue };
 
-  type JsonHolder<K extends string, A> = Record<K, JsonAlgebra<A>>;
+  type JsonHolder<K extends string, A> = Record<K, JsonValueF<A>>;
 }

--- a/src/entrypoints/json.d.ts
+++ b/src/entrypoints/json.d.ts
@@ -1,5 +1,11 @@
 declare namespace TSReset {
-  type JsonValue = string | number | boolean | JsonObject | JsonValue[] | null;
+  type JsonPrimitive = string | number | boolean | null;
+
+  type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
 
   type JsonObject = { [key: string]: JsonValue };
+
+  type JsonAlgebra<A> = JsonPrimitive | Record<string, A> | A[];
+
+  type JsonHolder<K extends string, A> = Record<K, JsonAlgebra<A>>;
 }

--- a/src/entrypoints/json.d.ts
+++ b/src/entrypoints/json.d.ts
@@ -1,11 +1,13 @@
 declare namespace TSReset {
   type JsonPrimitive = string | number | boolean | null;
 
+  type JsonComposite<A> = Record<string, A> | A[];
+
+  type JsonAlgebra<A> = JsonPrimitive | JsonComposite<A>;
+
   type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
 
   type JsonObject = { [key: string]: JsonValue };
-
-  type JsonAlgebra<A> = JsonPrimitive | Record<string, A> | A[];
 
   type JsonHolder<K extends string, A> = Record<K, JsonAlgebra<A>>;
 }

--- a/src/entrypoints/json.d.ts
+++ b/src/entrypoints/json.d.ts
@@ -1,5 +1,5 @@
 declare namespace TSReset {
-  type JsonValue = string | number | boolean | JsonValue[] | JsonObject | null;
+  type JsonValue = string | number | boolean | JsonObject | JsonValue[] | null;
 
   type JsonObject = { [key: string]: JsonValue };
 }

--- a/src/entrypoints/utils.d.ts
+++ b/src/entrypoints/utils.d.ts
@@ -1,4 +1,8 @@
 declare namespace TSReset {
+  type JsonValue = string | number | boolean | JsonValue[] | JsonObject | null;
+
+  type JsonObject = { [key: string]: JsonValue };
+
   type NonFalsy<T> = T extends false | 0 | "" | null | undefined | 0n
     ? never
     : T;

--- a/src/entrypoints/utils.d.ts
+++ b/src/entrypoints/utils.d.ts
@@ -1,8 +1,4 @@
 declare namespace TSReset {
-  type JsonValue = string | number | boolean | JsonValue[] | JsonObject | null;
-
-  type JsonObject = { [key: string]: JsonValue };
-
   type NonFalsy<T> = T extends false | 0 | "" | null | undefined | 0n
     ? never
     : T;

--- a/src/tests/fetch.ts
+++ b/src/tests/fetch.ts
@@ -3,7 +3,7 @@ import { doNotExecute, Equal, Expect } from "./utils";
 doNotExecute(async () => {
   const result = await fetch("/").then((res) => res.json());
 
-  type tests = [Expect<Equal<typeof result, unknown>>];
+  type tests = [Expect<Equal<typeof result, TSReset.JsonValue>>];
 });
 
 doNotExecute(async () => {

--- a/src/tests/json-parse.ts
+++ b/src/tests/json-parse.ts
@@ -3,7 +3,7 @@ import { doNotExecute, Equal, Expect } from "./utils";
 doNotExecute(() => {
   const result = JSON.parse("{}");
 
-  type tests = [Expect<Equal<typeof result, unknown>>];
+  type tests = [Expect<Equal<typeof result, TSReset.JsonValue>>];
 });
 
 doNotExecute(() => {

--- a/src/tests/json-parse.ts
+++ b/src/tests/json-parse.ts
@@ -52,7 +52,7 @@ doNotExecute(() => {
 });
 
 doNotExecute(() => {
-  type JsonValueWithMap = TSReset.JsonAlgebra<
+  type JsonValueWithMap = TSReset.JsonValueF<
     TSReset.JsonValue | Map<number, string>
   >;
 

--- a/src/tests/json-parse.ts
+++ b/src/tests/json-parse.ts
@@ -1,4 +1,7 @@
+import { isNumber, isString, isEntries } from "./type-guards";
 import { doNotExecute, Equal, Expect } from "./utils";
+
+const isNumberStringEntries = isEntries(isNumber, isString);
 
 doNotExecute(() => {
   const result = JSON.parse("{}");
@@ -7,8 +10,74 @@ doNotExecute(() => {
 });
 
 doNotExecute(() => {
-  // Make tests fail when someone tries to PR JSON.parse<T>
+  const result = JSON.parse('{"p": 5}', (key, value) =>
+    typeof value === "number" ? value * 2 : value,
+  );
 
-  // @ts-expect-error
-  const result = JSON.parse<string>("{}");
+  type tests = [Expect<Equal<typeof result, unknown>>];
+});
+
+doNotExecute(() => {
+  const result = JSON.parse<TSReset.JsonValue>('{"p": 5}', (key, value) =>
+    typeof value === "number" ? value * 2 : value,
+  );
+
+  type tests = [Expect<Equal<typeof result, TSReset.JsonValue>>];
+});
+
+doNotExecute(() => {
+  const result = JSON.parse('[[1,"one"],[2,"two"],[3,"three"]]', (key, value) =>
+    // @ts-expect-error
+    key === "" ? new Map(value) : value,
+  );
+});
+
+doNotExecute(() => {
+  const result = JSON.parse('[[1,"one"],[2,"two"],[3,"three"]]', (key, value) =>
+    key === "" && isNumberStringEntries(value) ? new Map(value) : value,
+  );
+
+  type tests = [Expect<Equal<typeof result, unknown>>];
+});
+
+doNotExecute(() => {
+  type JsonValueWithMap = TSReset.JsonValue | Map<number, string>;
+
+  const result = JSON.parse<JsonValueWithMap>(
+    '[[1,"one"],[2,"two"],[3,"three"]]',
+    (key, value) =>
+      // @ts-expect-error
+      key === "" && isNumberStringEntries(value) ? new Map(value) : value,
+  );
+});
+
+doNotExecute(() => {
+  type JsonValueWithMap = TSReset.JsonAlgebra<
+    TSReset.JsonValue | Map<number, string>
+  >;
+
+  const result = JSON.parse<JsonValueWithMap>(
+    '[[1,"one"],[2,"two"],[3,"three"]]',
+    (key, value) =>
+      // @ts-expect-error
+      key === "" && isNumberStringEntries(value) ? new Map(value) : value,
+  );
+});
+
+doNotExecute(() => {
+  type JsonValueWithMap =
+    | TSReset.JsonPrimitive
+    | Map<number, string>
+    | JsonObjectWithMap
+    | JsonValueWithMap[];
+
+  type JsonObjectWithMap = { [key: string]: JsonValueWithMap };
+
+  const result = JSON.parse<JsonValueWithMap>(
+    '[[1,"one"],[2,"two"],[3,"three"]]',
+    (key, value) =>
+      key === "" && isNumberStringEntries(value) ? new Map(value) : value,
+  );
+
+  type tests = [Expect<Equal<typeof result, JsonValueWithMap>>];
 });

--- a/src/tests/type-guards.ts
+++ b/src/tests/type-guards.ts
@@ -1,0 +1,23 @@
+export type TypeGuard<A> = (value: unknown) => value is A;
+
+export const isNumber: TypeGuard<number> = (value): value is number =>
+  typeof value === "number";
+
+export const isString: TypeGuard<string> = (value): value is string =>
+  typeof value === "string";
+
+export const isPair =
+  <A, B>(isFirst: TypeGuard<A>, isSecond: TypeGuard<B>): TypeGuard<[A, B]> =>
+  (value): value is [A, B] =>
+    Array.isArray(value) &&
+    value.length === 2 &&
+    isFirst(value[0]) &&
+    isSecond(value[1]);
+
+export const isArray =
+  <A>(isItem: TypeGuard<A>): TypeGuard<A[]> =>
+  (value): value is A[] =>
+    Array.isArray(value) && value.every((item) => isItem(item));
+
+export const isEntries = <A, B>(isKey: TypeGuard<A>, isValue: TypeGuard<B>) =>
+  isArray(isPair(isKey, isValue));


### PR DESCRIPTION
This PR builds on top of #121. Here's a [comparison](https://github.com/aaditmshah/ts-reset/compare/feature/json-value...aaditmshah:ts-reset:feature/json-parse-reviver) of the two branches.

## In response to &ldquo;Rules we won't add

### &ldquo;Generics for `JSON.parse`, `Response.json` etc&rdquo;

The primary concern is using generics to provide the return type of `JSON.parse` without providing a `reviver` argument. This is unsound, as you can see in the following code snippet.

```typescript
const str = JSON.parse<string>("42");

console.log(str); // logs the number 42, which is not a string
```

**This PR does not allow that.** Following are the changes that I made to the type definition of `JSON.parse`.

```typescript
interface JSON {
  parse(text: string): JsonValue;

  parse<A = unknown>(
    text: string,
    reviver: <K extends string>(
      this: JsonHolder<K, A>,
      key: K,
      value: JsonValueF<A>,
    ) => A,
  ): A;
}
```

And here are the type definitions of the utility types, `JsonValue`, `JsonValueF`, `JsonHolder`, etc.

```typescript
type JsonPrimitive = string | number | boolean | null;

type JsonComposite<A> = Record<string, A> | A[];

type JsonValueF<A> = JsonPrimitive | JsonComposite<A>;

type JsonValue = JsonPrimitive | JsonObject | JsonValue[];

type JsonObject = { [key: string]: JsonValue };

type JsonHolder<K extends string, A> = Record<K, JsonValueF<A>>;
```

## A sound and type-safe way to use `JSON.parse`

The new `JSON.parse` type definitions introduced in this PR are both type-safe and sound. For example, the following code snippet is invalid.

```typescript
const str = JSON.parse<string>("42"); // Invalid, because the argument for `reviver` was not provided
```

You can provide the return type of `JSON.parse` if and only if you also provide a valid argument for `reviver`. And, the `reviver` function has a sound type which constraints the return type that you can provide to `JSON.parse`.

This ensures that you never get an unsound result type when using `JSON.parse`. For example, if you only provide one argument to `JSON.parse`, i.e. the `text` that you want to parse, then the return type of the function is always `JsonValue`.

```typescript
const val = JSON.parse("42"); // The result type is JsonValue, which is type-safe and sound
```

If you want, you can provide the return type of `JSON.parse` along with a `reviver` to get a different result.

```typescript
type Option<A> = { value: A } | null;

const optionString = JSON.parse<Option<string>>("42", (key, value) =>
  typeof value === "string" ? { value } : null,
);

console.log(optionString); // logs null, because "42" is not parsed as a string
```

It's type-safe and sound because the return type provided for `JSON.parse` has to match both the input type and the return type of the `reviver`. Hence, you can't cheat.

```typescript
type Option<A> = { value: A } | null;

const optionString = JSON.parse<Option<string>>("42", (key, value) =>
  typeof value === "number" ? { value } : null, // Invalid: expected a `string` but received a `number`
);
```

I firmly believe that you'd really have to go out of your way to break the type-safety provided by the type definitions in this PR.

## What does the `reviver` do?

At its core, `JSON.parse` with a `reviver` is simply a [structural fold](https://hackage.haskell.org/package/data-fix-0.3.2/docs/Data-Fix.html#v:foldFix), a.k.a. a [catamorphism](https://en.wikipedia.org/wiki/Catamorphism). It takes an [initial](https://en.wikipedia.org/wiki/Initial_algebra) [F-algebra](https://en.wikipedia.org/wiki/F-algebra), i.e. the `reviver`, which describes how to convert values of type `JsonValueF<A>` into values of type `A`, and uses this description to convert any `JsonValue` into a value of type `A`.

This pure mathematical logic is muddied a little bit by the [implementation](https://tc39.es/ecma262/multipage/structured-data.html#sec-internalizejsonproperty) of `JSON.parse` with respect to the `reviver`. For example, if the `reviver` returns `undefined` then the corresponding object property or array element is deleted. This could lead to sparse arrays. However, since the return type is generic, we don't need to change the type of the `JSON.parse` function. [Garbage in, garbage out](https://en.wikipedia.org/wiki/Garbage_in,_garbage_out). If your `reviver` function can return `undefined`, then don't be surprised if you see `undefined` in the result.

Finally, the `this` context of the `reviver` is almost impossible to work with in a type-safe way. Hence, I gave it the very conservative type `JsonHolder` where `JsonHolder<K extends string, A> = Record<K, JsonValueF<A>>`. Essentially, if you have a reviver with the inputs `this`, `key`, and `value`, then the type of `this[key]` is the same as the type of `value`. The other properties, or array elements, of `this` could either be of the type `JsonValue` or of the return type `A`, depending upon whether or not they have been processed by the `reviver`. However, there's no safe way to access these properties or array elements. The best way to access them would be to use `Object.entries` or `Object.values` which return values of type `unknown`. Hence, there's no good reason to give `this` a more specific type to access the other object properties or array elements.

## Conclusion

Hopefully, I've convinced you that it's indeed possible to provide a safe and sound type definition for `JSON.parse`. And there are many advantages in doing so. The result type of `JSON.parse` is no longer `unknown`, unless you use a `reviver` but forget to provide the return type. In addition, the `reviver` function provides more type-safety too. No more `any` types anywhere.
