### PR TITLE
✨ Add strong typing for `JSON.stringify`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
       "import": "./dist/json-parse.mjs",
       "default": "./dist/json-parse.js"
     },
+    "./json-stringify": {
+      "types": "./dist/json-stringify.d.ts",
+      "import": "./dist/json-stringify.mjs",
+      "default": "./dist/json-stringify.js"
+    },
     "./json": {
       "types": "./dist/json.d.ts",
       "import": "./dist/json.mjs",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
       "import": "./dist/json-parse.mjs",
       "default": "./dist/json-parse.js"
     },
+    "./json": {
+      "types": "./dist/json.d.ts",
+      "import": "./dist/json.mjs",
+      "default": "./dist/json.js"
+    },
     "./fetch": {
       "types": "./dist/fetch.d.ts",
       "import": "./dist/fetch.mjs",

--- a/readme.md
+++ b/readme.md
@@ -316,29 +316,3 @@ const func: Func = () => {
 ```
 
 So, the only reasonable type for `Object.keys` to return is `Array<string>`.
-
-### Generics for `JSON.parse`, `Response.json` etc
-
-A common request is for `ts-reset` to add type arguments to functions like `JSON.parse`:
-
-```ts
-const str = JSON.parse<string>('"hello"');
-
-console.log(str); // string
-```
-
-This appears to improve the DX by giving you autocomplete on the thing that gets returned from `JSON.parse`.
-
-However, we argue that this is a lie to the compiler and so, unsafe.
-
-`JSON.parse` and `fetch` represent _validation boundaries_ - places where unknown data can enter your application code.
-
-If you _really_ know what data is coming back from a `JSON.parse`, then an `as` assertion feels like the right call:
-
-```ts
-const str = JSON.parse('"hello"') as string;
-
-console.log(str); // string
-```
-
-This provides the types you intend and also signals to the developer that this is _slightly_ unsafe.

--- a/readme.md
+++ b/readme.md
@@ -42,10 +42,10 @@ fetch("/")
 
 2. Create a `reset.d.ts` file in your project with these contents:
 
-```ts
-// Do not add any other lines of code to this file!
-import "@total-typescript/ts-reset";
-```
+   ```ts
+   // Do not add any other lines of code to this file!
+   import "@total-typescript/ts-reset";
+   ```
 
 3. Enjoy improved typings across your _entire_ project.
 

--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ TypeScript's built-in typings are not perfect. `ts-reset` makes them better.
 
 **With `ts-reset`**:
 
-- 👍 `.json` (in `fetch`) and `JSON.parse` both return `unknown`
+- 👍 `.json` (in `fetch`) and `JSON.parse` both return `JsonValue`
 - ✅ `.filter(Boolean)` behaves EXACTLY how you expect
 - 🥹 `array.includes` is widened to be more ergonomic
 - 🚀 And several more changes!
@@ -27,12 +27,12 @@ import "@total-typescript/ts-reset";
 const filteredArray = [1, 2, undefined].filter(Boolean); // number[]
 
 // Get rid of the any's in JSON.parse and fetch
-const result = JSON.parse("{}"); // unknown
+const result = JSON.parse("{}"); // JsonValue
 
 fetch("/")
   .then((res) => res.json())
   .then((json) => {
-    console.log(json); // unknown
+    console.log(json); // JsonValue
   });
 ```
 
@@ -56,10 +56,10 @@ By importing from `@total-typescript/ts-reset`, you're bundling _all_ the recomm
 To only import the rules you want, you can import like so:
 
 ```ts
-// Makes JSON.parse return unknown
+// Makes JSON.parse return JsonValue
 import "@total-typescript/ts-reset/json-parse";
 
-// Makes await fetch().then(res => res.json()) return unknown
+// Makes await fetch().then(res => res.json()) return JsonValue
 import "@total-typescript/ts-reset/fetch";
 ```
 
@@ -75,7 +75,7 @@ Below is a full list of all the rules available.
 
 ## Rules
 
-### Make `JSON.parse` return `unknown`
+### Make `JSON.parse` return `JsonValue`
 
 ```ts
 import "@total-typescript/ts-reset/json-parse";
@@ -88,16 +88,16 @@ import "@total-typescript/ts-reset/json-parse";
 const result = JSON.parse("{}"); // any
 ```
 
-By changing the result of `JSON.parse` to `unknown`, we're now forced to either validate the `unknown` to ensure it's the correct type (perhaps using [`zod`](https://github.com/colinhacks/zod)), or cast it with `as`.
+By changing the result of `JSON.parse` to `JsonValue`, we're now forced to either validate the `JsonValue` to ensure it's the correct type (perhaps using [`zod`](https://github.com/colinhacks/zod)), or cast it with `as`.
 
 ```ts
 // AFTER
 import "@total-typescript/ts-reset/json-parse";
 
-const result = JSON.parse("{}"); // unknown
+const result = JSON.parse("{}"); // JsonValue
 ```
 
-### Make `.json()` return `unknown`
+### Make `.json()` return `JsonValue`
 
 ```ts
 import "@total-typescript/ts-reset/fetch";
@@ -114,7 +114,7 @@ fetch("/")
   });
 ```
 
-By forcing `res.json` to return `unknown`, we're encouraged to distrust its results, making us more likely to validate the results of `fetch`.
+By forcing `res.json` to return `JsonValue`, we're encouraged to distrust its results, making us more likely to validate the results of `fetch`.
 
 ```ts
 // AFTER
@@ -123,7 +123,7 @@ import "@total-typescript/ts-reset/fetch";
 fetch("/")
   .then((res) => res.json())
   .then((json) => {
-    console.log(json); // unknown
+    console.log(json); // JsonValue
   });
 ```
 

--- a/src/entrypoints/fetch.d.ts
+++ b/src/entrypoints/fetch.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="utils.d.ts" />
+/// <reference path="json.d.ts" />
 
 interface Body {
   json(): Promise<TSReset.JsonValue>;

--- a/src/entrypoints/fetch.d.ts
+++ b/src/entrypoints/fetch.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="utils.d.ts" />
+
 interface Body {
-  json(): Promise<unknown>;
+  json(): Promise<TSReset.JsonValue>;
 }

--- a/src/entrypoints/json-parse.d.ts
+++ b/src/entrypoints/json-parse.d.ts
@@ -4,11 +4,21 @@ interface JSON {
   /**
    * Converts a JavaScript Object Notation (JSON) string into an object.
    * @param text A valid JSON string.
+   */
+  parse(text: string): TSReset.JsonValue;
+
+  /**
+   * Converts a JavaScript Object Notation (JSON) string into an object.
+   * @param text A valid JSON string.
    * @param reviver A function that transforms the results. This function is called for each member of the object.
    * If a member contains nested objects, the nested objects are transformed before the parent object is.
    */
-  parse(
+  parse<A = unknown>(
     text: string,
-    reviver?: (this: any, key: string, value: any) => any,
-  ): TSReset.JsonValue;
+    reviver: <K extends string>(
+      this: TSReset.JsonHolder<K, A>,
+      key: K,
+      value: TSReset.JsonAlgebra<A>,
+    ) => A,
+  ): A;
 }

--- a/src/entrypoints/json-parse.d.ts
+++ b/src/entrypoints/json-parse.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="utils.d.ts" />
+
 interface JSON {
   /**
    * Converts a JavaScript Object Notation (JSON) string into an object.
@@ -8,5 +10,5 @@ interface JSON {
   parse(
     text: string,
     reviver?: (this: any, key: string, value: any) => any,
-  ): unknown;
+  ): TSReset.JsonValue;
 }

--- a/src/entrypoints/json-parse.d.ts
+++ b/src/entrypoints/json-parse.d.ts
@@ -1,4 +1,4 @@
-/// <reference path="utils.d.ts" />
+/// <reference path="json.d.ts" />
 
 interface JSON {
   /**

--- a/src/entrypoints/json-parse.d.ts
+++ b/src/entrypoints/json-parse.d.ts
@@ -18,7 +18,7 @@ interface JSON {
     reviver: <K extends string>(
       this: TSReset.JsonHolder<K, A>,
       key: K,
-      value: TSReset.JsonAlgebra<A>,
+      value: TSReset.JsonValueF<A>,
     ) => A,
   ): A;
 }

--- a/src/entrypoints/json-stringify.d.ts
+++ b/src/entrypoints/json-stringify.d.ts
@@ -7,11 +7,11 @@ interface JSON {
    * @param replacer An array of strings and numbers that acts as an approved list for selecting the object properties that will be stringified.
    * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
    */
-  stringify(
-    value: unknown,
+  stringify<A>(
+    value: A,
     replacer?: (string | number)[] | null | undefined,
     space?: string | number | undefined,
-  ): string | undefined;
+  ): TSReset.StringifyResult<TSReset.ToJson<A>>;
 
   /**
    * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.

--- a/src/entrypoints/json-stringify.d.ts
+++ b/src/entrypoints/json-stringify.d.ts
@@ -1,0 +1,47 @@
+/// <reference path="json.d.ts" />
+
+interface JSON {
+  /**
+   * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+   * @param value A JavaScript value, usually an object or array, to be converted.
+   * @param replacer An array of strings and numbers that acts as an approved list for selecting the object properties that will be stringified.
+   * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+   */
+  stringify(
+    value: unknown,
+    replacer?: (string | number)[] | null | undefined,
+    space?: string | number | undefined,
+  ): string | undefined;
+
+  /**
+   * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+   * @param value A JavaScript value, usually an object or array, to be converted.
+   * @param replacer A function that transforms the results.
+   * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+   */
+  stringify<A>(
+    value: A,
+    replacer: (
+      this: TSReset.JsonComposite<A>,
+      key: string,
+      value: TSReset.ToJson<A>,
+    ) => TSReset.JsonValueF<A>,
+    space?: string | number | undefined,
+  ): string;
+
+  /**
+   * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+   * @param value A JavaScript value, usually an object or array, to be converted.
+   * @param replacer A function that transforms the results.
+   * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+   */
+  stringify<A>(
+    value: A,
+    replacer: (
+      this: TSReset.JsonComposite<A>,
+      key: string,
+      value: TSReset.ToJson<A>,
+    ) => TSReset.JsonValueF<A> | undefined,
+    space?: string | number | undefined,
+  ): string | undefined;
+}

--- a/src/entrypoints/json.d.ts
+++ b/src/entrypoints/json.d.ts
@@ -1,0 +1,5 @@
+declare namespace TSReset {
+  type JsonValue = string | number | boolean | JsonValue[] | JsonObject | null;
+
+  type JsonObject = { [key: string]: JsonValue };
+}

--- a/src/entrypoints/json.d.ts
+++ b/src/entrypoints/json.d.ts
@@ -3,11 +3,11 @@ declare namespace TSReset {
 
   type JsonComposite<A> = Record<string, A> | A[];
 
-  type JsonAlgebra<A> = JsonPrimitive | JsonComposite<A>;
+  type JsonValueF<A> = JsonPrimitive | JsonComposite<A>;
 
   type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
 
   type JsonObject = { [key: string]: JsonValue };
 
-  type JsonHolder<K extends string, A> = Record<K, JsonAlgebra<A>>;
+  type JsonHolder<K extends string, A> = Record<K, JsonValueF<A>>;
 }

--- a/src/entrypoints/json.d.ts
+++ b/src/entrypoints/json.d.ts
@@ -1,5 +1,11 @@
 declare namespace TSReset {
-  type JsonValue = string | number | boolean | JsonObject | JsonValue[] | null;
+  type JsonPrimitive = string | number | boolean | null;
+
+  type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
 
   type JsonObject = { [key: string]: JsonValue };
+
+  type JsonAlgebra<A> = JsonPrimitive | Record<string, A> | A[];
+
+  type JsonHolder<K extends string, A> = Record<K, JsonAlgebra<A>>;
 }

--- a/src/entrypoints/json.d.ts
+++ b/src/entrypoints/json.d.ts
@@ -1,11 +1,13 @@
 declare namespace TSReset {
   type JsonPrimitive = string | number | boolean | null;
 
+  type JsonComposite<A> = Record<string, A> | A[];
+
+  type JsonAlgebra<A> = JsonPrimitive | JsonComposite<A>;
+
   type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
 
   type JsonObject = { [key: string]: JsonValue };
-
-  type JsonAlgebra<A> = JsonPrimitive | Record<string, A> | A[];
 
   type JsonHolder<K extends string, A> = Record<K, JsonAlgebra<A>>;
 }

--- a/src/entrypoints/json.d.ts
+++ b/src/entrypoints/json.d.ts
@@ -11,5 +11,17 @@ declare namespace TSReset {
 
   type JsonHolder<K extends string, A> = Record<K, JsonValueF<A>>;
 
-  type ToJson<A> = A extends { toJSON(...args: unknown[]): infer T } ? T : A;
+  type ToJson<A> = A extends { toJSON(...args: any): infer T } ? T : A;
+
+  type SomeExtends<A, B> = A extends B ? undefined : never;
+
+  type SomeFunction = (...args: any) => any;
+
+  type SomeConstructor = new (...args: any) => any;
+
+  type UndefinedDomain = symbol | SomeFunction | SomeConstructor | undefined;
+
+  type StringifyValue<A> = A extends UndefinedDomain ? undefined : string;
+
+  type StringifyResult<A> = StringifyValue<A> | SomeExtends<UndefinedDomain, A>;
 }

--- a/src/entrypoints/json.d.ts
+++ b/src/entrypoints/json.d.ts
@@ -10,4 +10,6 @@ declare namespace TSReset {
   type JsonObject = { [key: string]: JsonValue };
 
   type JsonHolder<K extends string, A> = Record<K, JsonValueF<A>>;
+
+  type ToJson<A> = A extends { toJSON(...args: unknown[]): infer T } ? T : A;
 }

--- a/src/entrypoints/json.d.ts
+++ b/src/entrypoints/json.d.ts
@@ -1,5 +1,5 @@
 declare namespace TSReset {
-  type JsonValue = string | number | boolean | JsonValue[] | JsonObject | null;
+  type JsonValue = string | number | boolean | JsonObject | JsonValue[] | null;
 
   type JsonObject = { [key: string]: JsonValue };
 }

--- a/src/entrypoints/utils.d.ts
+++ b/src/entrypoints/utils.d.ts
@@ -1,4 +1,8 @@
 declare namespace TSReset {
+  type JsonValue = string | number | boolean | JsonValue[] | JsonObject | null;
+
+  type JsonObject = { [key: string]: JsonValue };
+
   type NonFalsy<T> = T extends false | 0 | "" | null | undefined | 0n
     ? never
     : T;

--- a/src/entrypoints/utils.d.ts
+++ b/src/entrypoints/utils.d.ts
@@ -1,8 +1,4 @@
 declare namespace TSReset {
-  type JsonValue = string | number | boolean | JsonValue[] | JsonObject | null;
-
-  type JsonObject = { [key: string]: JsonValue };
-
   type NonFalsy<T> = T extends false | 0 | "" | null | undefined | 0n
     ? never
     : T;

--- a/src/tests/fetch.ts
+++ b/src/tests/fetch.ts
@@ -3,7 +3,7 @@ import { doNotExecute, Equal, Expect } from "./utils";
 doNotExecute(async () => {
   const result = await fetch("/").then((res) => res.json());
 
-  type tests = [Expect<Equal<typeof result, unknown>>];
+  type tests = [Expect<Equal<typeof result, TSReset.JsonValue>>];
 });
 
 doNotExecute(async () => {

--- a/src/tests/json-parse.ts
+++ b/src/tests/json-parse.ts
@@ -3,7 +3,7 @@ import { doNotExecute, Equal, Expect } from "./utils";
 doNotExecute(() => {
   const result = JSON.parse("{}");
 
-  type tests = [Expect<Equal<typeof result, unknown>>];
+  type tests = [Expect<Equal<typeof result, TSReset.JsonValue>>];
 });
 
 doNotExecute(() => {

--- a/src/tests/json-parse.ts
+++ b/src/tests/json-parse.ts
@@ -52,7 +52,7 @@ doNotExecute(() => {
 });
 
 doNotExecute(() => {
-  type JsonValueWithMap = TSReset.JsonAlgebra<
+  type JsonValueWithMap = TSReset.JsonValueF<
     TSReset.JsonValue | Map<number, string>
   >;
 

--- a/src/tests/json-parse.ts
+++ b/src/tests/json-parse.ts
@@ -1,4 +1,7 @@
+import { isNumber, isString, isEntries } from "./type-guards";
 import { doNotExecute, Equal, Expect } from "./utils";
+
+const isNumberStringEntries = isEntries(isNumber, isString);
 
 doNotExecute(() => {
   const result = JSON.parse("{}");
@@ -7,8 +10,74 @@ doNotExecute(() => {
 });
 
 doNotExecute(() => {
-  // Make tests fail when someone tries to PR JSON.parse<T>
+  const result = JSON.parse('{"p": 5}', (key, value) =>
+    typeof value === "number" ? value * 2 : value,
+  );
 
-  // @ts-expect-error
-  const result = JSON.parse<string>("{}");
+  type tests = [Expect<Equal<typeof result, unknown>>];
+});
+
+doNotExecute(() => {
+  const result = JSON.parse<TSReset.JsonValue>('{"p": 5}', (key, value) =>
+    typeof value === "number" ? value * 2 : value,
+  );
+
+  type tests = [Expect<Equal<typeof result, TSReset.JsonValue>>];
+});
+
+doNotExecute(() => {
+  const result = JSON.parse('[[1,"one"],[2,"two"],[3,"three"]]', (key, value) =>
+    // @ts-expect-error
+    key === "" ? new Map(value) : value,
+  );
+});
+
+doNotExecute(() => {
+  const result = JSON.parse('[[1,"one"],[2,"two"],[3,"three"]]', (key, value) =>
+    key === "" && isNumberStringEntries(value) ? new Map(value) : value,
+  );
+
+  type tests = [Expect<Equal<typeof result, unknown>>];
+});
+
+doNotExecute(() => {
+  type JsonValueWithMap = TSReset.JsonValue | Map<number, string>;
+
+  const result = JSON.parse<JsonValueWithMap>(
+    '[[1,"one"],[2,"two"],[3,"three"]]',
+    (key, value) =>
+      // @ts-expect-error
+      key === "" && isNumberStringEntries(value) ? new Map(value) : value,
+  );
+});
+
+doNotExecute(() => {
+  type JsonValueWithMap = TSReset.JsonAlgebra<
+    TSReset.JsonValue | Map<number, string>
+  >;
+
+  const result = JSON.parse<JsonValueWithMap>(
+    '[[1,"one"],[2,"two"],[3,"three"]]',
+    (key, value) =>
+      // @ts-expect-error
+      key === "" && isNumberStringEntries(value) ? new Map(value) : value,
+  );
+});
+
+doNotExecute(() => {
+  type JsonValueWithMap =
+    | TSReset.JsonPrimitive
+    | Map<number, string>
+    | JsonObjectWithMap
+    | JsonValueWithMap[];
+
+  type JsonObjectWithMap = { [key: string]: JsonValueWithMap };
+
+  const result = JSON.parse<JsonValueWithMap>(
+    '[[1,"one"],[2,"two"],[3,"three"]]',
+    (key, value) =>
+      key === "" && isNumberStringEntries(value) ? new Map(value) : value,
+  );
+
+  type tests = [Expect<Equal<typeof result, JsonValueWithMap>>];
 });

--- a/src/tests/json-stringify.ts
+++ b/src/tests/json-stringify.ts
@@ -1,0 +1,84 @@
+import { doNotExecute, Equal, Expect } from "./utils";
+
+const michael = { name: "Michael Jackson", age: 50 };
+
+const importantDates = new Map([
+  [
+    'Charles Darwin publishes his book "On the Origin of Species"',
+    new Date("1859-11-24"),
+  ],
+  [
+    'Karl Marx publishes the first volume of his book "Das Kaptial"',
+    new Date("1867-09-14"),
+  ],
+  [
+    "Albert Einstein's paper on mass-energy equivalence is received",
+    new Date("1905-09-27"),
+  ],
+  [
+    "Mahatma Gandhi begins his 300km march against the British salt tax",
+    new Date("1930-03-12"),
+  ],
+  [
+    'Martin Luther King Jr. delivers his "I have a dream" speech',
+    new Date("1963-08-28"),
+  ],
+  [
+    "Nelson Mandela is released after 27 years imprisonment in South Africa",
+    new Date("1990-02-11"),
+  ],
+]);
+
+doNotExecute(() => {
+  const result = JSON.stringify(michael);
+
+  type tests = [Expect<Equal<typeof result, string | undefined>>];
+});
+
+doNotExecute(() => {
+  const result = JSON.stringify(michael, ["name"]);
+
+  type tests = [Expect<Equal<typeof result, string | undefined>>];
+});
+
+doNotExecute(() => {
+  const result = JSON.stringify(michael, null, 4);
+
+  type tests = [Expect<Equal<typeof result, string | undefined>>];
+});
+
+doNotExecute(() => {
+  const result = JSON.stringify(michael, ["name"], "\t");
+
+  type tests = [Expect<Equal<typeof result, string | undefined>>];
+});
+
+doNotExecute(() => {
+  type Value = Map<string, Date>;
+
+  const result = JSON.stringify<Value>(importantDates, (key, value) =>
+    // @ts-expect-error
+    Object.fromEntries(value),
+  );
+});
+
+doNotExecute(() => {
+  type Value = Date | Map<string, Date>;
+
+  const result = JSON.stringify<Value>(importantDates, (key, value) =>
+    typeof value === "string" ? value : Object.fromEntries(value),
+  );
+
+  type tests = [Expect<Equal<typeof result, string>>];
+});
+
+doNotExecute(() => {
+  type Value = Date | Map<string, Date>;
+
+  const result = JSON.stringify<Value>(importantDates, (key, value) => {
+    if (typeof value !== "string") return Object.fromEntries(value);
+    return new Date(value) < new Date("1900-01-01") ? undefined : value;
+  });
+
+  type tests = [Expect<Equal<typeof result, string | undefined>>];
+});

--- a/src/tests/json-stringify.ts
+++ b/src/tests/json-stringify.ts
@@ -30,34 +30,142 @@ const importantDates = new Map([
 ]);
 
 doNotExecute(() => {
+  const result = JSON.stringify(undefined);
+  type tests = [Expect<Equal<typeof result, undefined>>];
+});
+
+doNotExecute(() => {
+  // A function is treated as undefined by the JSON serializer
+  const fn = () => {};
+  const result = JSON.stringify(fn);
+  type tests = [Expect<Equal<typeof result, undefined>>];
+});
+
+doNotExecute(() => {
+  // A constructor is treated as undefined by the JSON serializer
+  const fn = class {};
+  const result = JSON.stringify(fn);
+  type tests = [Expect<Equal<typeof result, undefined>>];
+});
+
+doNotExecute(() => {
+  // A symbol is treated as undefined by the JSON serializer
+  const x = Symbol();
+  const result = JSON.stringify(x);
+  type tests = [Expect<Equal<typeof result, undefined>>];
+});
+
+doNotExecute(() => {
+  // If the incoming value can possibly be undefined then the return type can
+  // possibly be undefined
+  const result = JSON.stringify(5 as undefined | number);
+  type tests = [Expect<Equal<typeof result, string | undefined>>];
+});
+
+doNotExecute(() => {
+  // If the incoming value can possibly be a function then the return type can
+  // possibly be undefined
+  const result = JSON.stringify(5 as number | (() => number));
+  type tests = [Expect<Equal<typeof result, string | undefined>>];
+});
+
+doNotExecute(() => {
+  // If the incoming value can possibly be a constructor then the return type can
+  // possibly be undefined
+  const result = JSON.stringify(5 as number | (new () => number));
+  type tests = [Expect<Equal<typeof result, string | undefined>>];
+});
+
+doNotExecute(() => {
+  // If the incoming value can possibly be a symbol then the return type can
+  // possibly be undefined
+  const result = JSON.stringify(5 as number | symbol);
+  type tests = [Expect<Equal<typeof result, string | undefined>>];
+});
+
+doNotExecute(() => {
+  // If the type of the incoming value is `any` we can't assume anything about
+  // it so return the broadest possible type
+  const result = JSON.stringify(undefined as any);
+  type tests = [Expect<Equal<typeof result, string | undefined>>];
+});
+
+doNotExecute(() => {
+  // If the type of the incoming value is `unknown` we can't assume anything
+  // about it so return the broadest possible type
+  const result = JSON.stringify(undefined as unknown);
+  type tests = [Expect<Equal<typeof result, string | undefined>>];
+});
+
+doNotExecute(() => {
+  // If the type of the incoming value is `void` we can't assume anything
+  // about it so return the broadest possible type
+  const result = JSON.stringify(undefined as void);
+  type tests = [Expect<Equal<typeof result, string | undefined>>];
+});
+
+doNotExecute(() => {
+  // If the type of the incoming value is "non-nullish" we can be sure it's not
+  // undefined, but we can't be sure it isn't a function (treated as undefined)
+  // so return the broadest possible type.
+  const fn = () => {};
+  const result = JSON.stringify(fn as Object);
+  type tests = [Expect<Equal<typeof result, string | undefined>>];
+});
+
+doNotExecute(() => {
+  // If the type of the incoming value contains "object" (meaning non-primitive)
+  // we can't be sure it isn't a function (treated as undefined) so return the
+  // broadest possible type.
+  const value = null as null | string | number | boolean | object;
+  const result = JSON.stringify(value);
+  type tests = [Expect<Equal<typeof result, string | undefined>>];
+});
+
+doNotExecute(() => {
+  // If the type of the incoming value contains "Record<K, any>" (in which K is
+  // any valid index type, e.g. string or symbol) we can't be sure it isn't a
+  // function so return the broadest possible type.
+  const value = null as null | string | Record<string, any>;
+  const result = JSON.stringify(value);
+  type tests = [Expect<Equal<typeof result, string | undefined>>];
+});
+
+doNotExecute(() => {
+  const value = null as null | string | Record<string, unknown> | any[];
+  const result = JSON.stringify(value);
+  type tests = [Expect<Equal<typeof result, string>>];
+});
+
+doNotExecute(() => {
   const result = JSON.stringify(michael);
 
-  type tests = [Expect<Equal<typeof result, string | undefined>>];
+  type tests = [Expect<Equal<typeof result, string>>];
 });
 
 doNotExecute(() => {
   const result = JSON.stringify(michael, ["name"]);
 
-  type tests = [Expect<Equal<typeof result, string | undefined>>];
+  type tests = [Expect<Equal<typeof result, string>>];
 });
 
 doNotExecute(() => {
   const result = JSON.stringify(michael, null, 4);
 
-  type tests = [Expect<Equal<typeof result, string | undefined>>];
+  type tests = [Expect<Equal<typeof result, string>>];
 });
 
 doNotExecute(() => {
   const result = JSON.stringify(michael, ["name"], "\t");
 
-  type tests = [Expect<Equal<typeof result, string | undefined>>];
+  type tests = [Expect<Equal<typeof result, string>>];
 });
 
 doNotExecute(() => {
   type Value = Map<string, Date>;
 
+  // @ts-expect-error
   const result = JSON.stringify<Value>(importantDates, (key, value) =>
-    // @ts-expect-error
     Object.fromEntries(value),
   );
 });

--- a/src/tests/json-stringify.ts
+++ b/src/tests/json-stringify.ts
@@ -8,7 +8,7 @@ const importantDates = new Map([
     new Date("1859-11-24"),
   ],
   [
-    'Karl Marx publishes the first volume of his book "Das Kaptial"',
+    'Karl Marx publishes the first volume of his book "Das Kapital"',
     new Date("1867-09-14"),
   ],
   [
@@ -20,7 +20,7 @@ const importantDates = new Map([
     new Date("1930-03-12"),
   ],
   [
-    'Martin Luther King Jr. delivers his "I have a dream" speech',
+    'Martin Luther King Jr. delivers his famous "I have a dream" speech',
     new Date("1963-08-28"),
   ],
   [

--- a/src/tests/type-guards.ts
+++ b/src/tests/type-guards.ts
@@ -1,0 +1,23 @@
+export type TypeGuard<A> = (value: unknown) => value is A;
+
+export const isNumber: TypeGuard<number> = (value): value is number =>
+  typeof value === "number";
+
+export const isString: TypeGuard<string> = (value): value is string =>
+  typeof value === "string";
+
+export const isPair =
+  <A, B>(isFirst: TypeGuard<A>, isSecond: TypeGuard<B>): TypeGuard<[A, B]> =>
+  (value): value is [A, B] =>
+    Array.isArray(value) &&
+    value.length === 2 &&
+    isFirst(value[0]) &&
+    isSecond(value[1]);
+
+export const isArray =
+  <A>(isItem: TypeGuard<A>): TypeGuard<A[]> =>
+  (value): value is A[] =>
+    Array.isArray(value) && value.every((item) => isItem(item));
+
+export const isEntries = <A, B>(isKey: TypeGuard<A>, isValue: TypeGuard<B>) =>
+  isArray(isPair(isKey, isValue));


### PR DESCRIPTION
This PR builds on top of #123. Here's a [comparison](https://github.com/aaditmshah/ts-reset/compare/feature/json-parse-reviver...aaditmshah:ts-reset:feature/json-stringify) of the two branches.

## Related pull requests

- This PR is an alternative to #21
   - The biggest difference is that the `replacer` function in this PR has a strong type, i.e. no `any` or `unknown`.
   - This PR also handles specialization of the return type, as does #21.
   - However, this PR also handles the `toJSON` method correctly, as well as constructor functions and symbols.

## How do I use the `replacer` function?

The biggest change made in this PR is providing a sound type for `JSON.stringify` when the `replacer` function is provided. You can now use generics to specify what the input and return types of the `replacer` function should be.

**Best Practice:** Always provide the generic type to `JSON.stringify` if you're using the `replacer` function. If you don't do so, then TypeScript will use the incorrect type definition of `JSON.stringify` from the built-in library.

So, how do you use the new and improved `replacer` function? Consider the following example.

```typescript
declare const importantDates: Map<string, Date>;

type Value = Date | Map<string, Date>;

// The type of `result` is just `string` because the `replacer` function never returns `undefined`.
const result = JSON.stringify<Value>(importantDates, (key, value) =>
  // The type of `value` is `string | Map<string, Date>`.
  typeof value === "string" ? value : Object.fromEntries(value)
);
```

There are a lot of things going on here.

1. We provided the input generic type `Date | Map<string, Date>` instead of just `Map<string, Date>`. This is because the `replacer` processes the input value recursively. Hence, the first time when the `replacer` is called with `Map<string, Date>`, it converts the input map into an object. Subsequently, the `replacer` is called on the values of that object which are of type `Date`. Hence, we need to provide the input generic type `Date | Map<string, Date>`.

   If we provide just `Map<string, Date>` as the input generic type then we'll get an error.

   ```typescript
   declare const importantDates: Map<string, Date>;

   type Value = Map<string, Date>;

   const result = JSON.stringify<Value>(importantDates, (key, value) =>
     Object.fromEntries(value) // TypeError: Type `Date` is not assignable to type `Map<string, Date>`
   );
   ```

2. Notice that even though the input generic type is `Date | Map<string, Date>`, yet the type of `value` inside the `replacer` function is `string | Map<string, Date>`. This is because `Date` objects in JavaScript have a `toJSON` property which returns a `string`, and `JSON.stringify` calls the `toJSON` method to change the `Date` to a `string` before calling the `replacer` function.

   The new and improved type definitions for `JSON.stringify` are aware of this fact and provide the correct type.

3. Notice that the return type is just `string` instead of `string | undefined`. This is because the `replacer` function in the above example never returns `undefined`. Hence, `JSON.stringify` can never return `undefined`.

   On the flip side, we could return `undefined` from the `replacer` function to filter out certain values. However, if we do so then the return type would be `string | undefined`. Consider the following example.

   ```typescript
   declare const importantDates: Map<string, Date>;

   type Value = Date | Map<string, Date>;

   // The type of `result` is `string | undefined` because the `replacer` returns `undefined`.
   const result = JSON.stringify<Value>(importantDates, (key, value) => {
     if (typeof value !== "string") return Object.fromEntries(value);
     // Filter out all dates before the 20th century.
     return new Date(value) < new Date("1900-01-01") ? undefined : value;
   });
   ```

## Conclusion

As you can see, we can give very strong type definitions for `JSON.stringify` without compromising on type-safety and soundness.