### PR TITLE
Narrow set has if true

### DIFF
--- a/src/entrypoints/set-has.d.ts
+++ b/src/entrypoints/set-has.d.ts
@@ -1,9 +1,9 @@
 /// <reference path="utils.d.ts" />
 
 interface Set<T> {
-  has(value: T | (TSReset.WidenLiteral<T> & {})): boolean;
+  has(value: T | (TSReset.WidenLiteral<T> & {})): value is T;
 }
 
 interface ReadonlySet<T> {
-  has(value: T | (TSReset.WidenLiteral<T> & {})): boolean;
+  has(value: T | (TSReset.WidenLiteral<T> & {})): value is T;
 }


### PR DESCRIPTION
If the set includes the item then it's safe to narrow it to the type of the set.

```ts
const colors = new Set(['red', 'blue'] as const);
const inputColor = 'red' as string;
if (colors.has(inputColor)) {
  inputColor // => 'red' | 'blue'
}
```

