### PR TITLE
Narrow types for certain cases of Array.includes

### DIFF
--- a/src/entrypoints/array-includes.d.ts
+++ b/src/entrypoints/array-includes.d.ts
@@ -1,6 +1,21 @@
 /// <reference path="utils.d.ts" />
 
+type NarrowArrayElement<T, Found = never> = TSReset.IsUnion<T> extends true
+  ? never
+  : T extends readonly [infer A, ...infer B]
+  ? TSReset.IsStrictLiteral<A> extends true
+    ? NarrowArrayElement<B, Found | A>
+    : never
+  : Found;
+
 interface ReadonlyArray<T> {
+  includes(
+    searchElement: [NarrowArrayElement<this>] extends [never]
+      ? never
+      : T | (TSReset.WidenLiteral<T> & {}),
+    fromIndex?: number,
+  ): searchElement is NarrowArrayElement<this>;
+
   includes(
     searchElement: T | (TSReset.WidenLiteral<T> & {}),
     fromIndex?: number,
@@ -8,6 +23,13 @@ interface ReadonlyArray<T> {
 }
 
 interface Array<T> {
+  includes(
+    searchElement: [NarrowArrayElement<this>] extends [never]
+      ? never
+      : T | (TSReset.WidenLiteral<T> & {}),
+    fromIndex?: number,
+  ): searchElement is NarrowArrayElement<this>;
+
   includes(
     searchElement: T | (TSReset.WidenLiteral<T> & {}),
     fromIndex?: number,

--- a/src/entrypoints/utils.d.ts
+++ b/src/entrypoints/utils.d.ts
@@ -14,4 +14,16 @@ declare namespace TSReset {
     : T extends symbol
     ? symbol
     : T;
+
+  export type UnionToIntersection<U> = (
+    U extends any ? (k: U) => void : never
+  ) extends (k: infer I) => void
+    ? I
+    : never;
+
+  type IsUnion<T> = [T] extends [UnionToIntersection<T>] ? false : true;
+
+  type IsStrictLiteral<T> = WidenLiteral<UnionToIntersection<T>> extends T
+    ? false
+    : true;
 }

--- a/src/tests/array-includes.ts
+++ b/src/tests/array-includes.ts
@@ -64,3 +64,111 @@ doNotExecute(async () => {
     true,
   );
 });
+
+doNotExecute(async () => {
+  // All entries are well known => value is narrowed
+  const options = [1, 2, 3] as readonly [1, 2, 3];
+  const value = 2 as 2 | 3 | 4 | 5;
+
+  if (options.includes(value)) {
+    type tests = [Expect<Equal<typeof value, 2 | 3>>];
+  } else {
+    type tests = [Expect<Equal<typeof value, 4 | 5>>];
+  }
+});
+
+doNotExecute(async () => {
+  // Entries are not well known => value is not narrowed
+  const options = [1, 2, 3] as readonly number[];
+  const value = 2 as 2 | 3 | 4 | 5;
+
+  if (options.includes(value)) {
+    type tests = [Expect<Equal<typeof value, 2 | 3 | 4 | 5>>];
+  } else {
+    type tests = [Expect<Equal<typeof value, 2 | 3 | 4 | 5>>];
+  }
+});
+
+doNotExecute(async () => {
+  // Entries are not well known => value is not narrowed
+  const options = [1, 2, 3] as number[];
+  const value = 2 as 2 | 3 | 4 | 5;
+
+  if (options.includes(value)) {
+    type tests = [Expect<Equal<typeof value, 2 | 3 | 4 | 5>>];
+  } else {
+    type tests = [Expect<Equal<typeof value, 2 | 3 | 4 | 5>>];
+  }
+});
+
+doNotExecute(async () => {
+  // Entries are not well known => value is not narrowed
+  const options = [] as readonly 1[];
+  const value = 1 as 1 | 2;
+
+  if (options.includes(value)) {
+    type tests = [Expect<Equal<typeof value, 1 | 2>>];
+  } else {
+    type tests = [Expect<Equal<typeof value, 1 | 2>>];
+  }
+});
+
+doNotExecute(async () => {
+  // Entries are not well known => value is not narrowed
+  const options = [] as 1[];
+  const value = 1 as 1 | 2;
+
+  if (options.includes(value)) {
+    type tests = [Expect<Equal<typeof value, 1 | 2>>];
+  } else {
+    type tests = [Expect<Equal<typeof value, 1 | 2>>];
+  }
+});
+
+doNotExecute(async () => {
+  // Some entries are well known, others not => value is not narrowed
+  const options = [1, 2, 3] as readonly [1, 2, 3 | 4];
+  const value = 2 as 2 | 3 | 4 | 5;
+
+  if (options.includes(value)) {
+    type tests = [Expect<Equal<typeof value, 2 | 3 | 4 | 5>>];
+  } else {
+    type tests = [Expect<Equal<typeof value, 2 | 3 | 4 | 5>>];
+  }
+});
+
+doNotExecute(async () => {
+  // Some entries are well known, others not => value is not narrowed
+  const options = [1, 2, 3] as [1, 2, 3 | 4];
+  const value = 2 as 2 | 3 | 4 | 5;
+
+  if (options.includes(value)) {
+    type tests = [Expect<Equal<typeof value, 2 | 3 | 4 | 5>>];
+  } else {
+    type tests = [Expect<Equal<typeof value, 2 | 3 | 4 | 5>>];
+  }
+});
+
+doNotExecute(async () => {
+  // Union of arrays with well known entries => value is narrowed
+  const options = [1, 2, 3] as readonly [1, 2, 3] | readonly [1, 2, 4];
+  const value = 2 as 2 | 3 | 4 | 5;
+
+  if (options.includes(value)) {
+    type tests = [Expect<Equal<typeof value, 2 | 3 | 4 | 5>>];
+  } else {
+    type tests = [Expect<Equal<typeof value, 2 | 3 | 4 | 5>>];
+  }
+});
+
+doNotExecute(async () => {
+  // Union of arrays with well known entries => value is narrowed
+  const options = [1, 2, 3] as [1, 2, 3] | [1, 2, 4];
+  const value = 2 as 2 | 3 | 4 | 5;
+
+  if (options.includes(value)) {
+    type tests = [Expect<Equal<typeof value, 2 | 3 | 4 | 5>>];
+  } else {
+    type tests = [Expect<Equal<typeof value, 2 | 3 | 4 | 5>>];
+  }
+});

--- a/src/tests/array-includes.ts
+++ b/src/tests/array-includes.ts
@@ -155,8 +155,10 @@ doNotExecute(async () => {
   const value = 2 as 2 | 3 | 4 | 5;
 
   if (options.includes(value)) {
+    // @ts-expect-error: Typescript limitation. TODO: fix when possible
     type tests = [Expect<Equal<typeof value, 2 | 3 | 4 | 5>>];
   } else {
+    // @ts-expect-error: Typescript limitation. TODO: fix when possible
     type tests = [Expect<Equal<typeof value, 2 | 3 | 4 | 5>>];
   }
 });
@@ -167,8 +169,10 @@ doNotExecute(async () => {
   const value = 2 as 2 | 3 | 4 | 5;
 
   if (options.includes(value)) {
+    // @ts-expect-error: Typescript limitation. TODO: fix when possible
     type tests = [Expect<Equal<typeof value, 2 | 3 | 4 | 5>>];
   } else {
+    // @ts-expect-error: Typescript limitation. TODO: fix when possible
     type tests = [Expect<Equal<typeof value, 2 | 3 | 4 | 5>>];
   }
 });


### PR DESCRIPTION
As discussed in #49 a simple `: searchElement is T` won't do, because the assertion is too strong and produces wrong types, especially in the "opposite" cases (e.g. else blocks).

My suggestion is to reenable the type guard only for cases where it is safe: Tuple with well known entries - so only entries that are literals without unions.

For example this is safe, because x is `1 | 2 | 3` if **and only if** the array contains it:
```ts
const values = [1, 2] as [1, 2] // or as const
declare const x: 2 | 3;

if (values.includes(x)) {
  console.log(x);
  //          ^? // 2
} else {
  console.log(x);
  //          ^? // 3
}
```

### Known problem
There is one remaining problem that I know of, where the type guard would do the wrong thing and I cannot imagine a way to prevent this. But depending on how you look at it, it might be ok, since it seems to me that this is actually due to a wider TypeScript problem (bug?)

If the array itself is a union:
```ts
const values2 = [1, 2] as [1, 2] | [2, 3]
declare const x2: 3 | 4

if (values2.includes(x2)) {
  console.log(x2);
  //          ^? // 3
} else {
  console.log(x2);
  //          ^? // 4 <-- wrong! if x is 3 we would still hit the else case
}
```

But the same problem arises with other type guards as well:
```ts
const f1 = (x: number): x is 1 => x === 1;
const f2 = (x: number): x is 2 => x === 2;
const f = f1 as typeof f1 | typeof f2;
const n = 2 as 1 | 2 | 3;

if (f(n)) {
  console.log(n);
  //          ^? // 1 | 2
} else {
  console.log(n);
  //          ^? // 3 <-- wrong!
}
```

[Playground](https://www.typescriptlang.org/play?#code/CYUwxgNghgTiAEA7KBbEBnADlMCAqAygEoYgAu8A3gFDzxkCemCA6gJaiIAybZIMUCAB48APngBeeHnggAHn0TB08dGRhtEAc1p14AflXrNOvfABc02QpBKViAK4oARv111Djl27OWZ8xWV4ZwB7EIgQKER3A2CwiKiYv2tAlWc2LU0yGMN0zMRs3ysA2yD0BhdwnNUK0Igk6QBual15TBCYCkZmeABVRDYQxDwQgEkC-nRwMkHEIV7xKQAKGN6U0pUohlilgGtLXoBKSXEANxCOCyQQU594Y5K7eD3LTQAzfnhR44kzi+BqqMGogbvxmrpughRuh+rMRIt4ABtPAAXXWT0RsKGI3GfBgUzAMyG8LRhjegimV3UDhA4LokK+6AIxkJPDxgnhkng7E4bP4HKxwzGE3x0zhYnEjyCeGq5IgUwa1Np1AAvi0GQA5WAwEIAdwAgjABAwAKIRNAFEQAGngADEQg4lFyQbcYAjCCQpmQAHTQwWcqUqJW6TygmC6ZKB+BwKDAIYQbaI96ffU273p5MweAAIRRIekxFIPuhzI0rN4-OE+slNiewY88C1Rr1huNZpAFrIQmzNvtjuA8AAPvBqxHrq6x32lOCsvxybh4CRY-GGK2oAxOTQ6JpIA5QOgVmYprAwAALdudyyIps6g1G9cX2xdsintjoURoqOIl38PNmBs-uG-5XDIw5LB6Rbejyth8gIwhiPAABkVAqocVoxG8OooOMoByPolheK4MDoXQhyWMeMBno+BTwG+jbai296muaT5CC+b6iHStGILu+6HnoFFUSxBTJGBEFelBHAwRWcGcshlCoSReiYSE2FKPI+FIE4RFKWRcThJEiDNGq1CzjA84IGuG4IVu3G8Rg-F0IJ57CWQV43oxbauWxr7vp+tZBN+YZ-v+oYTsBonPOJ5CSbyMkcgh8mKRhWE4RpBHafwunkZElEuR2T60SoHl3l5BWWux75cTuEB7g5MTOdRblWGJhYSdB3DxfB4hJWhKWqWleEZd4xG6HpoQGVExktAA9DN0inlAFB0W8mggOY1BgEMajwKcgg0ioUiIgAjDaABMaJQCoJ3nWic3wB08BXfAW2IGo1CgJAsAIK9O1yJYZ1DvAADMM5vM8e21Rg3o1XVB5yIcxy2b9BnehAIRaEsCPNHQ93AXoAB6+iqrI8oIMj22o+jmPY7oeP4-AROqrN80sKetjRo6AzaHZtX7g9iBPfAjqzA94Pauu6A2rwwQxrs6CbdtFCQwdgNHad8AXU910a1rw6ImdNrA3mn3QHAL1K-AchnZYwNAwALC0bDg0sKsYGdMM8XzDnW4jVC6CjERoxjWNnYcOPwPT+NMyqpOUhTb1UyHvsR1HwExyzOYOF07OqKgCB0Uq8BvI9IQvp8ABEiAdCgggV-QTAIFoDiwEEz26iAED1L9FBvMdXJY8NRF6XIRXwP3vxW5IEhSMdzQ98XavPP9WkjSPY9q+Io8z1IZ3z5b4NSH32sN8wITg8fw6Qufi-729FCC7vJ-98OgPDqDTsu28SyIH7CfoEnTGv9U7zQZozYmsdO7xwDpTIO1Mf7hzpqAhmGcgA)