### PR TITLE
Use narrower type for JSON.parse

### DIFF
--- a/src/entrypoints/fetch.d.ts
+++ b/src/entrypoints/fetch.d.ts
@@ -1,3 +1,3 @@
 interface Body {
-  json(): Promise<unknown>;
+  json(): Promise<import("../json-types").JsonValue>;
 }

--- a/src/entrypoints/json-parse.d.ts
+++ b/src/entrypoints/json-parse.d.ts
@@ -8,5 +8,5 @@ interface JSON {
   parse(
     text: string,
     reviver?: (this: any, key: string, value: any) => any,
-  ): unknown;
+  ): import('../json-types').JsonValue;
 }

--- a/src/json-types.d.ts
+++ b/src/json-types.d.ts
@@ -1,0 +1,3 @@
+export type JsonObject = { [key: string]: JsonValue }
+export type JsonArray = JsonValue[]
+export type JsonValue = JsonObject | JsonArray | number | string | boolean | null;

--- a/src/tests/fetch.ts
+++ b/src/tests/fetch.ts
@@ -1,9 +1,10 @@
 import { doNotExecute, Equal, Expect } from "./utils";
+import { JsonValue } from "../json-types";
 
 doNotExecute(async () => {
   const result = await fetch("/").then((res) => res.json());
 
-  type tests = [Expect<Equal<typeof result, unknown>>];
+  type tests = [Expect<Equal<typeof result, JsonValue>>];
 });
 
 doNotExecute(async () => {

--- a/src/tests/json-parse.ts
+++ b/src/tests/json-parse.ts
@@ -1,9 +1,10 @@
 import { doNotExecute, Equal, Expect } from "./utils";
+import { JsonValue } from "../json-types";
 
 doNotExecute(() => {
   const result = JSON.parse("{}");
 
-  type tests = [Expect<Equal<typeof result, unknown>>];
+  type tests = [Expect<Equal<typeof result, JsonValue>>];
 });
 
 doNotExecute(() => {


### PR DESCRIPTION
Seems like using a narrower type here would be better, allowing users to do less type checking, since JSON is a pretty simple format.

Might also be worth exposing the JSON types for people to use.

I didn't attempt to update the docs, just putting forward the idea for now!