### PR TITLE
Implements WidenLiteral in terms of `Join` helper

### DIFF
--- a/src/entrypoints/utils.d.ts
+++ b/src/entrypoints/utils.d.ts
@@ -3,15 +3,19 @@ declare namespace TSReset {
     ? never
     : T;
 
-  type WidenLiteral<T> = T extends string
-    ? string
-    : T extends number
-    ? number
-    : T extends boolean
-    ? boolean
-    : T extends bigint
-    ? bigint
-    : T extends symbol
-    ? symbol
-    : T;
+  type Primitive =
+    | string
+    | number
+    | boolean
+    | bigint
+    | symbol
+
+  type Join<Lower, Upper>
+    = Upper extends Upper
+    ? Lower extends Upper
+    ? Upper
+    : never
+    : never
+
+  type WidenLiteral<T> = T extends Primitive ? Join<T, Primitive> : T
 }


### PR DESCRIPTION
Happy to add additional tests or make adjustments. Also I'm not sure if I should inline `Join`, will that leak into the global namespace the way I declared it?

This alternate definition of `WidenLiteral` should be at parity with the current implementation. It works by distributing both types (the lower bound, and the upper bound), and choosing the upper member in the event of an intersection.

I named it [join](https://en.wikipedia.org/wiki/Join_and_meet) because that feels like the correct term, but I don't have a math background so I could be wrong.