### PR TITLE
Improvment to `Array.isArray`

### DIFF
--- a/src/entrypoints/is-array.d.ts
+++ b/src/entrypoints/is-array.d.ts
@@ -1,3 +1,3 @@
 interface ArrayConstructor {
-  isArray(arg: any): arg is unknown[];
+  isArray<T>(arg: 0 extends 1 & T ? never : T): arg is 0 extends 1 & T ? never : T extends Array<unknown> | ReadonlyArray<unknown> ? T : T[] extends T ? T[] : never;
 }

--- a/src/entrypoints/is-array.d.ts
+++ b/src/entrypoints/is-array.d.ts
@@ -1,3 +1,3 @@
 interface ArrayConstructor {
-  isArray<T>(arg: 0 extends 1 & T ? never : T): arg is 0 extends 1 & T ? never : T extends Array<unknown> | ReadonlyArray<unknown> ? T : T[] extends T ? T[] : never;
+  isArray<T>(arg: 0 extends 1 & T ? never : T): arg is 0 extends 1 & T ? never : T extends unknown[] | readonly unknown[] ? T : T[] extends T ? T[] : never;
 }

--- a/src/tests/is-array.ts
+++ b/src/tests/is-array.ts
@@ -9,6 +9,30 @@ doNotExecute(() => {
 });
 
 doNotExecute(() => {
+  const maybeArr = [1, 2, 3] as unknown[];
+
+  if (Array.isArray(maybeArr)) {
+    type tests = [Expect<Equal<typeof maybeArr, unknown[]>>];
+  }
+});
+
+doNotExecute(() => {
+  const maybeArr = [1, 2, 3] as any;
+
+  if (Array.isArray(maybeArr)) {
+    type tests = [Expect<Equal<typeof maybeArr, any[]>>];
+  }
+});
+
+doNotExecute(() => {
+  const maybeArr = [1, 2, 3] as any[];
+
+  if (Array.isArray(maybeArr)) {
+    type tests = [Expect<Equal<typeof maybeArr, any[]>>];
+  }
+});
+
+doNotExecute(() => {
   const arrOrString = [] as string[] | string;
 
   if (Array.isArray(arrOrString)) {
@@ -17,9 +41,79 @@ doNotExecute(() => {
 });
 
 doNotExecute(() => {
-  let path: string | string[] = [];
+  const arrOrString = [] as readonly string[] | string;
+
+  if (Array.isArray(arrOrString)) {
+    type tests = [Expect<Equal<typeof arrOrString, readonly string[]>>];
+  }
+});
+
+doNotExecute(() => {
+  const arrOrString = [] as readonly string[] | string[] | string;
+
+  if (Array.isArray(arrOrString)) {
+    type tests = [Expect<Equal<typeof arrOrString, readonly string[] | string[]>>];
+  }
+});
+
+doNotExecute(() => {
+  const arrOrString = [] as string[] | string;
+
+  if (Array.isArray(arrOrString)) return;
+  type tests = [Expect<Equal<typeof arrOrString, string>>];
+});
+
+doNotExecute(() => {
+  const arrOrString = [] as readonly string[] | string;
+
+  if (Array.isArray(arrOrString)) return;
+  type tests = [Expect<Equal<typeof arrOrString, string>>];
+});
+
+doNotExecute(() => {
+  const arrOrString = [] as readonly string[] | string[] | string;
+
+  if (Array.isArray(arrOrString)) return;
+  type tests = [Expect<Equal<typeof arrOrString, string>>];
+});
+
+doNotExecute(() => {
+  let arrOrString = "" as string | [1, 2];
+
+  if (Array.isArray(arrOrString)) {
+    type tests = [Expect<Equal<typeof arrOrString, [1, 2]>>];
+  }
+});
+
+doNotExecute(() => {
+  let path = [] as string | string[];
 
   const paths = Array.isArray(path) ? path : [path];
 
   type tests = [Expect<Equal<typeof paths, string[]>>];
+});
+
+doNotExecute(() => {
+  function test<T>(value: T) {
+    type Unarray<T> = T extends Array<infer U> ? U : T;
+    const inner = <X extends Unarray<T>>(v: X[]) => {};
+
+    if (Array.isArray(value)) {
+      inner(value);
+    }
+  }
+});
+
+doNotExecute(async () => {
+  function makeArray<Item>(input: Item | ReadonlyArray<Item> | Array<Item>) {
+    if (Array.isArray(input)) {
+      return input;
+    }
+    return [input];
+  }
+
+  const [first] = makeArray([{ a: "1" }, { a: "2" }, { a: "3" }] as const);
+
+  // No error!
+  first.a;
 });


### PR DESCRIPTION
This PR improves the type inference of `Array.isArray`.

It builds on the changes made in https://github.com/total-typescript/ts-reset/pull/56 and https://github.com/total-typescript/ts-reset/pull/23 to solve https://github.com/total-typescript/ts-reset/issues/48.