### PR TITLE
Make String.startsWith return `${P}${string}`

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,11 @@
       "types": "./dist/array-index-of.d.ts",
       "import": "./dist/array-index-of.mjs",
       "default": "./dist/array-index-of.js"
+    },
+    "./string-starts-with": {
+      "types": "./dist/string-starts-with.d.ts",
+      "import": "./dist/string-starts-with.mjs",
+      "default": "./dist/string-starts-with.js"
     }
   },
   "keywords": [],

--- a/src/entrypoints/recommended.d.ts
+++ b/src/entrypoints/recommended.d.ts
@@ -6,3 +6,4 @@
 /// <reference path="set-has.d.ts" />
 /// <reference path="map-has.d.ts" />
 /// <reference path="array-index-of.d.ts" />
+/// <reference path="string-starts-with.d.ts" />

--- a/src/entrypoints/string-starts-with.d.ts
+++ b/src/entrypoints/string-starts-with.d.ts
@@ -1,0 +1,9 @@
+interface String {
+  /**
+   * Returns true if the sequence of elements of searchString converted to a String is the
+   * same as the corresponding elements of this object (converted to a String) starting at
+   * position. Otherwise returns false.
+   */
+  startsWith<P extends string>(searchString: P): this is `${P}${string}`;
+  startsWith<P extends string>(searchString: P, position: 0): this is `${P}${string}`;
+}

--- a/src/tests/string-starts-with.ts
+++ b/src/tests/string-starts-with.ts
@@ -1,0 +1,29 @@
+import { doNotExecute, Equal, Expect, ExpectFalse } from "./utils";
+
+doNotExecute(() => {
+  const str: string = '#hashtag';
+
+  if (str.startsWith('#')) {
+    type tests = [Expect<Equal<typeof str, `#${string}`>>];
+  };
+
+  if (str.startsWith('#', 0)) {
+    type tests = [Expect<Equal<typeof str, `#${string}`>>];
+  };
+
+  if (str.startsWith('#', 1)) {
+    type tests = [
+      ExpectFalse<Equal<typeof str, `#${string}`>>,
+      Expect<Equal<typeof str, string>>,
+    ];
+  };
+});
+
+doNotExecute(() => {
+  const str = '#hashtag' as const;
+  
+  if (str.startsWith('#')) {
+    // type does not narrow
+    type tests = [Expect<Equal<typeof str, '#hashtag'>>];
+  };
+});


### PR DESCRIPTION
See: https://github.com/microsoft/TypeScript/issues/46958