### PR TITLE
Better Object.entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,11 @@
       "types": "./dist/storage.d.ts",
       "import": "./dist/storage.mjs",
       "default": "./dist/storage.js"
+    },
+    "./object-entries": {
+      "types": "./dist/object-entries.d.ts",
+      "import": "./dist/object-entries.mjs",
+      "default": "./dist/object-entries.js"
     }
   },
   "keywords": [],

--- a/src/entrypoints/object-entries.d.ts
+++ b/src/entrypoints/object-entries.d.ts
@@ -1,3 +1,3 @@
 interface ObjectConstructor {
-  entries<const T extends object>(o: T): { [K in keyof T]: [K, T[K]] }[keyof T][];
+  entries<const T>(o: T): T extends ArrayLike<any> ? { [K in Extract<keyof T, number>]: [K, T[K]] }[number][] : { [K in keyof T]: [K, T[K]] }[keyof T][];
 }

--- a/src/entrypoints/object-entries.d.ts
+++ b/src/entrypoints/object-entries.d.ts
@@ -1,3 +1,3 @@
 interface ObjectConstructor {
-  entries<T>(o: T): T extends ArrayLike<any> ? { [K in Extract<keyof T, number>]: [K, T[K]] }[number][] : { [K in keyof T]: [K, T[K]] }[keyof T][];
+  entries<T>(o: T): T extends ArrayLike<any> ? { [K in Extract<keyof T, number>]: [`${K}`, T[K]] }[number][] : { [K in keyof T]: [K, T[K]] }[keyof T][];
 }

--- a/src/entrypoints/object-entries.d.ts
+++ b/src/entrypoints/object-entries.d.ts
@@ -1,3 +1,3 @@
 interface ObjectConstructor {
-  entries<const T>(o: T): T extends ArrayLike<any> ? { [K in Extract<keyof T, number>]: [K, T[K]] }[number][] : { [K in keyof T]: [K, T[K]] }[keyof T][];
+  entries<T>(o: T): T extends ArrayLike<any> ? { [K in Extract<keyof T, number>]: [K, T[K]] }[number][] : { [K in keyof T]: [K, T[K]] }[keyof T][];
 }

--- a/src/entrypoints/object-entries.d.ts
+++ b/src/entrypoints/object-entries.d.ts
@@ -1,0 +1,3 @@
+interface ObjectConstructor {
+  entries<const T extends object>(o: T): { [K in keyof T]: [K, T[K]] }[keyof T][];
+}

--- a/src/entrypoints/recommended.d.ts
+++ b/src/entrypoints/recommended.d.ts
@@ -6,3 +6,4 @@
 /// <reference path="set-has.d.ts" />
 /// <reference path="map-has.d.ts" />
 /// <reference path="array-index-of.d.ts" />
+/// <reference path="object-entries.d.ts" />

--- a/src/tests/object-entries.ts
+++ b/src/tests/object-entries.ts
@@ -11,6 +11,17 @@ doNotExecute(async () => {
     // Complex values
     Expect<Equal<typeof result2, (['a', true] | ['b', 'string'] | ['c', { readonly field: 1 }])[]>>,
     // Array
-    Expect<Equal<typeof result3, [number, 1 | 2 | 3][]>>,
+    Expect<Equal<typeof result3, [`${number}`, 1 | 2 | 3][]>>,
   ];
+});
+
+doNotExecute(async () => {
+  const array = [1, 2, 3];
+  const readonlyArray = [1, 2, 3] as const;
+  const result1 = Object.entries(array);
+  const result2 = Object.entries(readonlyArray);
+
+  // Make sure arrays' index is a string in the result
+  result1[0][0] satisfies `${number}`;
+  result2[0][0] satisfies `${number}`;
 });

--- a/src/tests/object-entries.ts
+++ b/src/tests/object-entries.ts
@@ -1,9 +1,9 @@
 import { doNotExecute, Equal, Expect } from './utils';
 
 doNotExecute(async () => {
-  const result1 = Object.entries({ a: 1, b: 2, c: 3 });
-  const result2 = Object.entries({ a: true, b: 'string', c: { field: 1 } });
-  const result3 = Object.entries([1, 2, 3]);
+  const result1 = Object.entries({ a: 1, b: 2, c: 3 } as const);
+  const result2 = Object.entries({ a: true, b: 'string', c: { field: 1 } } as const);
+  const result3 = Object.entries([1, 2, 3] as const);
 
   type tests = [
     // Basic functionality test

--- a/src/tests/object-entries.ts
+++ b/src/tests/object-entries.ts
@@ -1,0 +1,16 @@
+import { doNotExecute, Equal, Expect } from './utils';
+
+doNotExecute(async () => {
+  const result1 = Object.entries({ a: 1, b: 2, c: 3 });
+  const result2 = Object.entries({ a: true, b: 'string', c: { field: 1 } });
+  const result3 = Object.entries([1, 2, 3]);
+
+  type tests = [
+    // Basic functionality test
+    Expect<Equal<typeof result1, (['a', 1] | ["b", 2] | ['c', 3])[]>>,
+    // Complex values
+    Expect<Equal<typeof result2, (['a', true] | ['b', 'string'] | ['c', { readonly field: 1 }])[]>>,
+    // Array
+    Expect<Equal<typeof result3, [number, 1 | 2 | 3][]>>,
+  ];
+});


### PR DESCRIPTION
### Intro
This type changes the behaviour of `Object.entries` to return more specific types:
```ts
Object.entries({ a: 1, b: 2, c: 3 } as const);
// Before change: [string, 1 | 2 | 3][]
// After change: (["a", 1] | ["b", 2] | ["c", 3])[]

Object.entries({ a: true, b: 'string', c: { field: 1 } } as const);
// Before change: [string, true | "string" | { readonly field: 1; }][]
// After change: (["a", true] | ["b", "string"] | ["c", { readonly field: 1; }])[]

Object.entries([1, 2, 3] as const);
// Before change: [string, 1 | 2 | 3][]
// After change: [number, 2 | 1 | 3][]
```

### Caveats
- In TypeScript 5.0, the function would automatically transform any object or array into a read-only object using the `const` keyword for more specific results. Therefore, the difference between the results of `Object.entries` in TypeScript 5 would be even bigger, since the `as const` part would be omitted.
In earlier versions, for specific results, the `as const` assertion needs to be added to inputs.
- The order of the elements in the result of `Object.entries` cannot be relied on, therefore a union of tuples is returned instead of a deterministic tuple (i.e. `(["a", 1"] | ["b", 2])[]` and not `[["a", 1], ["b", 2]]`)