### PR TITLE
Added improved typings for Array.every

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,11 @@
       "types": "./dist/storage.d.ts",
       "import": "./dist/storage.mjs",
       "default": "./dist/storage.js"
+    },
+    "./every-boolean": {
+      "types": "./dist/every-boolean.d.ts",
+      "import": "./dist/every-boolean.mjs",
+      "default": "./dist/every-boolean.js"
     }
   },
   "keywords": [],

--- a/src/entrypoints/every-boolean.d.ts
+++ b/src/entrypoints/every-boolean.d.ts
@@ -1,0 +1,23 @@
+/// <reference path="utils.d.ts" />
+
+interface Array<T> {
+  every<U>(
+    predicate: BooleanConstructor,
+    thisArg?: any,
+  ): this is this extends U[]
+    ? TSReset.NonFalsy<T>[]
+    : this[number] extends TSReset.NonFalsy<T>
+    ? this
+    : never;
+}
+
+interface ReadonlyArray<T> {
+  every<U>(
+    predicate: BooleanConstructor,
+    thisArg?: any,
+  ): this is this extends U[]
+    ? TSReset.NonFalsy<T>[]
+    : this[number] extends TSReset.NonFalsy<T>
+    ? this
+    : never;
+}

--- a/src/tests/every-boolean.ts
+++ b/src/tests/every-boolean.ts
@@ -1,0 +1,72 @@
+import { doNotExecute, Equal, Expect } from "./utils";
+
+doNotExecute(() => {
+  const arr = [1, 2, 3, undefined];
+
+  if (arr.every(Boolean)) {
+    type tests = [Expect<Equal<typeof arr, number[]>>];
+  } else {
+    type tests = [Expect<Equal<typeof arr, (number | undefined)[]>>];
+  }
+});
+
+doNotExecute(() => {
+  const arr = [1, 2, 3, "four"];
+
+  if (arr.every(Boolean)) {
+    type tests = [Expect<Equal<typeof arr, (number | string)[]>>];
+  } else {
+    type tests = [Expect<Equal<typeof arr, never>>];
+  }
+});
+
+doNotExecute(() => {
+  const arr = ["1", "2"] as const;
+
+  if (arr.every(Boolean)) {
+    type tests = [Expect<Equal<typeof arr, readonly ["1", "2"]>>];
+  } else {
+    type tests = [Expect<Equal<typeof arr, never>>];
+  }
+});
+
+doNotExecute(() => {
+  const arr = ["1", "2", undefined] as const;
+
+  if (arr.every(Boolean)) {
+    type tests = [Expect<Equal<typeof arr, never>>];
+  } else {
+    type tests = [Expect<Equal<typeof arr, readonly ["1", "2", undefined]>>];
+  }
+});
+
+doNotExecute(() => {
+  const arr = [0, null, undefined, false, ""] as const;
+
+  if (arr.every(Boolean)) {
+    type tests = [Expect<Equal<typeof arr, never>>];
+  } else {
+    type tests = [
+      Expect<Equal<typeof arr, readonly [0, null, undefined, false, ""]>>,
+    ];
+  }
+});
+
+doNotExecute(() => {
+  const arr: (0 | null | undefined | false | "" | 0n)[] = [
+    0,
+    null,
+    undefined,
+    false,
+    "",
+    0n,
+  ];
+
+  if (arr.every(Boolean)) {
+    type tests = [Expect<Equal<typeof arr, never[]>>];
+  } else {
+    type tests = [
+      Expect<Equal<typeof arr, (0 | null | undefined | false | "" | 0n)[]>>,
+    ];
+  }
+});


### PR DESCRIPTION
This PR adds improved typings to `Array.every` when using the `Boolean` constructor, in a way that's very similar to what's already being done for `Array.filter`.

After extensive testing, these types seem to always behave as expected, narrowing the type of the array or tuple down as much as possible (possibly even to `never`).

I haven't added this feature to `recommended.d.ts` because I'd like to have some feedback on this first, but I feel like it would make sense to add it there since this is very much in line with the `Array.filter` improvements, which are recommended.