### PR TITLE
fix: filter error with `as const` unions

### DIFF
--- a/.changeset/metal-moose-march.md
+++ b/.changeset/metal-moose-march.md
@@ -1,0 +1,7 @@
+---
+"@total-typescript/ts-reset": patch
+---
+
+@author: none23
+
+Fixed a bug where running .filter on a union of arrays would not work.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v3
         with:
           node-version: 20.x

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "prettier": "^3.2.5",
     "tsx": "^3.14.0",
     "turbo": "^1.13.3",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.4"
   },
   "prettier": {
     "arrowParens": "always",

--- a/package.json
+++ b/package.json
@@ -118,5 +118,6 @@
     "singleQuote": false,
     "tabWidth": 2,
     "useTabs": false
-  }
+  },
+  "packageManager": "pnpm@9.7.1+sha512.faf344af2d6ca65c4c5c8c2224ea77a81a5e8859cbc4e06b1511ddce2f0151512431dd19e6aff31f2c6a8f5f2aced9bd2273e1fed7dd4de1868984059d2c4247"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^1.13.3
         version: 1.13.3
       typescript:
-        specifier: ^5.4.5
-        version: 5.4.5
+        specifier: ^5.5.4
+        version: 5.5.4
 
 packages:
 
@@ -1173,8 +1173,8 @@ packages:
     resolution: {integrity: sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==}
     engines: {node: '>= 0.4'}
 
-  typescript@5.4.5:
-    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
+  typescript@5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2527,7 +2527,7 @@ snapshots:
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
 
-  typescript@5.4.5: {}
+  typescript@5.5.4: {}
 
   unbox-primitive@1.0.2:
     dependencies:

--- a/src/entrypoints/filter-boolean.d.ts
+++ b/src/entrypoints/filter-boolean.d.ts
@@ -1,9 +1,15 @@
 /// <reference path="utils.d.ts" />
 
 interface Array<T> {
-  filter(predicate: BooleanConstructor, thisArg?: any): TSReset.NonFalsy<T>[];
+  filter<S extends T>(
+    predicate: BooleanConstructor,
+    thisArg?: any,
+  ): TSReset.NonFalsy<S>[];
 }
 
 interface ReadonlyArray<T> {
-  filter(predicate: BooleanConstructor, thisArg?: any): TSReset.NonFalsy<T>[];
+  filter<S extends T>(
+    predicate: BooleanConstructor,
+    thisArg?: any,
+  ): TSReset.NonFalsy<S>[];
 }

--- a/src/tests/array-index-of.ts
+++ b/src/tests/array-index-of.ts
@@ -65,6 +65,12 @@ doNotExecute(async () => {
   );
 });
 
+doNotExecute(() => {
+  const arr: string[] | number[] = {} as any;
+
+  const result = arr.indexOf("abc");
+});
+
 // lastIndexOf
 
 doNotExecute(async () => {
@@ -130,4 +136,10 @@ doNotExecute(async () => {
     // @ts-expect-error
     true,
   );
+});
+
+doNotExecute(() => {
+  const arr: string[] | number[] = {} as any;
+
+  const result = arr.lastIndexOf("abc");
 });

--- a/src/tests/filter-boolean.ts
+++ b/src/tests/filter-boolean.ts
@@ -38,3 +38,11 @@ doNotExecute(() => {
 
   type tests = [Expect<Equal<typeof result, never[]>>];
 });
+
+doNotExecute(() => {
+  const arr: string[] | number[] = {} as any;
+
+  const result = arr.filter((x) => typeof x === "string");
+
+  type tests = [Expect<Equal<typeof result, string[]>>];
+});


### PR DESCRIPTION
Works for typescript versions >=5.2.2 
[TS Playground demo](https://www.typescriptlang.org/play/?noUncheckedIndexedAccess=true&declaration=false&pretty=true&isolatedModules=true&verbatimModuleSyntax=true&allowSyntheticDefaultImports=false&useUnknownInCatchVariables=true&ts=5.2.2&isolatedDeclarations=false#code/FAEwpgxgNghgTmABAOxgWzAZwA4wkgFQGUAlLMAF0QG9hFEKBPbJAOQHtkAxGKTRgDwEAfIgC8iAojAAPCmGQhMiAGa9MSAD6IADIm0AiA-pQBXKFBOnFYFQEtkYECZ3I69RAH4UYAG5g4d3oALkkAbmAAX2BgB3k4NXxEAEE4OBhBERp3AHoc1TsoeIAKbAQQOwgYeVCAIXZ2KDAYZABhTkwKOFMICnY4ABoGAAs7TFSAc09QlsYASlDiMg0KADoObnVM4QBtAF0I+nsigIEiaTkFJUlhUvLK6rA6hqaW9uRO7t7+oYpR8bgUxmyHmi1I5DWGx4fEERF2ByiMTiAUSSDIMBAnCgjFS6W22XoeQKJzgdycDxqiHqjWabQ6XR6fUGIzGk2miFmC0k4JW6040P4Qnhh2J8TOF3kimUIjJFSqlOprzpHwZ32Zf1ZgPZnLBy0ofM2MLOwsRMQg9IYWCoElo9GSoR21EQAGswIxQgBGRCRIZO13uxAAJm9ewG7lqDr9btCAGZvb6XdHEAAWENhyIc5TmlURYAqay9OycRAQYaQZ3FGShf3sFQMZhgWuWzpzAmIBAUUxwZDNig7GR7VbHEqMcSiRirf2IUQeuamnIAKmARIIVswZot8DgXokOw9Q2s4HsjhAQ2Te2A2c6HLSwd3+8Qh9sDicZ72mZL9I3Kt7O5v26HQoSkVWk5yJDxEAAPU8S8LXkTo73-QNAJJYoQJaMD8g8aDgAXHIgA)

Closes https://github.com/total-typescript/ts-reset/issues/193