### PR TITLE
Fix filter(Boolean) bug when immediately returning filter result

### DIFF
--- a/src/entrypoints/filter-boolean.d.ts
+++ b/src/entrypoints/filter-boolean.d.ts
@@ -4,12 +4,12 @@ interface Array<T> {
   filter<S extends T>(
     predicate: BooleanConstructor,
     thisArg?: any,
-  ): TSReset.NonFalsy<S>[];
+  ): NoInfer<TSReset.NonFalsy<S>[]>;
 }
 
 interface ReadonlyArray<T> {
   filter<S extends T>(
     predicate: BooleanConstructor,
     thisArg?: any,
-  ): TSReset.NonFalsy<S>[];
+  ): NoInfer<TSReset.NonFalsy<S>[]>;
 }

--- a/src/tests/filter-boolean.ts
+++ b/src/tests/filter-boolean.ts
@@ -46,3 +46,53 @@ doNotExecute(() => {
 
   type tests = [Expect<Equal<typeof result, string[]>>];
 });
+
+doNotExecute(() => {
+  const arrOk: { key: string }[] = [{ key: "val" }];
+  const arrBad: {}[] = [{}];
+
+  // Look ma, no error!
+  ((): { key: string }[] => {
+    return arrOk.filter(Boolean);
+  })();
+  ((): { key: string }[] => {
+    const result = arrOk.filter(Boolean);
+    return result;
+  })();
+
+  // Look ma, proper errors!
+  ((): { key: string }[] => {
+    // @ts-expect-error
+    return arrBad.filter(Boolean);
+  })();
+  ((): { key: string }[] => {
+    const result = arrBad.filter(Boolean);
+    // @ts-expect-error
+    return result;
+  })();
+});
+
+doNotExecute(() => {
+  const arrOk: readonly { key: string }[] = [{ key: "val" }];
+  const arrBad: readonly {}[] = [{}];
+
+  // Look ma, no error!
+  ((): { key: string }[] => {
+    return arrOk.filter(Boolean);
+  })();
+  ((): { key: string }[] => {
+    const result = arrOk.filter(Boolean);
+    return result;
+  })();
+
+  // Look ma, proper errors!
+  ((): { key: string }[] => {
+    // @ts-expect-error
+    return arrBad.filter(Boolean);
+  })();
+  ((): { key: string }[] => {
+    const result = arrBad.filter(Boolean);
+    // @ts-expect-error
+    return result;
+  })();
+});


### PR DESCRIPTION
When using ts-reset, the following should generate a type error, but it doesn't:
```
function example(): { key: string }[] {
  // Should generate a type error, but doesn't!
  return [{}].filter(Boolean);
}
```

The problem is with contextual typing and how it's interacting with generic type inference. When inferring the generic type parameter `S` in the filter signature, TypeScript is applying contextual typing using the function's return type `{ key: string }[]` annotation, and tries to make the expression match. So it infers `S = { key: "string" }`. That satisfies `S extends {}`, thereby allowing the code to spuriously pass type checking.

This only occurs when the result of `filter` is immediately returned. Assigning it to an intermediate variable does correctly generate a type error, because in this case `result` is typed via generic type inference, not contextual typing of the function's return type.
```
function example(): { key: string }[] {
  const result = [{}].filter(Boolean);
  // Correctly generates a type error
  return result;
}
```

Using `NoInfer` on the return type prevents `S` from being inferred via contextual typing, instead forcing `S` to be inferred using generic type inference (in this example, correctly inferred as `{}`).

Note: A potential DX problem with this solution is that `NoInfer<...>` is now visible in the return type.